### PR TITLE
Fixed bug: transforming intermediate cloud to global frame of ref before...

### DIFF
--- a/cloud_merge/include/cloud_merge_node.h
+++ b/cloud_merge/include/cloud_merge_node.h
@@ -500,7 +500,7 @@ void CloudMergeNode<PointType>::controlCallback(const std_msgs::String& controlS
                     intCloudId = aSemanticRoom.addIntermediateRoomCloud(transformed_cloud, transform);
                 }
 
-//                m_CloudMerge.transformIntermediateCloud(transform,"/map");
+                m_CloudMerge.transformIntermediateCloud(transform,"/map");
 //                transformed_cloud = m_CloudMerge.getIntermediateCloud();
 
 //                sensor_msgs::PointCloud2 msg_cloud;


### PR DESCRIPTION
... adding it to the merged cloud (it's still saved in the local frame of ref)
