### PR TITLE
Clear metaroom

### DIFF
--- a/object_manager/CMakeLists.txt
+++ b/object_manager/CMakeLists.txt
@@ -31,6 +31,11 @@ add_service_files(
    GetDynamicObjectService.srv
 )
 
+add_message_files(
+  FILES
+  DynamicObjectTracks.msg
+)
+
 generate_messages(
   DEPENDENCIES
   std_msgs

--- a/object_manager/include/dynamic_object.h
+++ b/object_manager/include/dynamic_object.h
@@ -36,6 +36,11 @@ public:
     struct ObjectTrack{
         tf::Transform pose;
         CloudPtr cloud;
+
+        ObjectTrack()
+        {
+            cloud = CloudPtr(new Cloud());
+        }
     };
 
    DynamicObject(bool verbose = false);

--- a/object_manager/include/dynamic_object.h
+++ b/object_manager/include/dynamic_object.h
@@ -14,6 +14,8 @@
 #include <pcl/correspondence.h>
 #include <pcl/features/vfh.h>
 
+#include <geometry_msgs/Transform.h>
+#include <tf/transform_datatypes.h>
 
 class DynamicObject  {
 public:
@@ -31,6 +33,11 @@ public:
 
     typedef boost::shared_ptr<DynamicObject> Ptr;
 
+    struct ObjectTrack{
+        tf::Transform pose;
+        CloudPtr cloud;
+    };
+
    DynamicObject(bool verbose = false);
    ~DynamicObject();
 
@@ -45,6 +52,7 @@ public:
    void computeBbox();
    void computeNormals(double, int noThreads = 4);
    void computeVFHFeatures();
+   void addObjectTrack(tf::Transform pose, CloudPtr cloud);
 
    bool operator==(const DynamicObject& rhs); // equality operator -> deep comparison of all fields
    bool operator!=(const DynamicObject& rhs); // equality operator -> deep comparison of all fields
@@ -62,6 +70,7 @@ public:
 
    CloudPtr                         m_points;
    std::vector<CloudPtr>            m_vAdditionalViews;
+   std::vector<ObjectTrack>         m_vObjectTracks;
    int                              m_noAdditionalViews;
    NormalCloudPtr                   m_normals;
    std::string                      m_label;

--- a/object_manager/include/dynamic_object_xml_parser.h
+++ b/object_manager/include/dynamic_object_xml_parser.h
@@ -24,6 +24,10 @@ public:
     std::string saveAsXML(DynamicObject::Ptr object, std::string xml_filename = "", std::string cloud_filename = "");
     DynamicObject::Ptr loadFromXML(std::string filename, bool load_cloud = true);
 
+
+    void saveObjectTrackToXml(tf::Transform pose, CloudPtr cloud, QXmlStreamWriter* xmlWriter, std::string nodeName, std::string cloudFilename);
+    DynamicObject::ObjectTrack readObjectTrackFromXml(QXmlStreamReader* xmlReader, std::string nodeName, std::string objectFolder, bool& errorReading);
+
     std::string m_rootFolderPath;
     bool m_verbose;
 

--- a/object_manager/include/dynamic_object_xml_parser.h
+++ b/object_manager/include/dynamic_object_xml_parser.h
@@ -26,7 +26,7 @@ public:
 
 
     void saveObjectTrackToXml(tf::Transform pose, CloudPtr cloud, QXmlStreamWriter* xmlWriter, std::string nodeName, std::string cloudFilename);
-    DynamicObject::ObjectTrack readObjectTrackFromXml(QXmlStreamReader* xmlReader, std::string nodeName, std::string objectFolder, bool& errorReading);
+    DynamicObject::ObjectTrack readObjectTrackFromXml(QXmlStreamReader* xmlReader, std::string nodeName, std::string objectFolder, bool& errorReading, bool load_cloud = true);
 
     std::string m_rootFolderPath;
     bool m_verbose;

--- a/object_manager/include/object_manager.h
+++ b/object_manager/include/object_manager.h
@@ -23,6 +23,9 @@
 #include <object_manager/DynamicObjectsService.h>
 #include <object_manager/GetDynamicObjectService.h>
 
+// Custom messages
+#include <object_manager/DynamicObjectTracks.h>
+
 // PCL includes
 #include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
@@ -82,6 +85,8 @@ public:
     bool returnObjectMask(std::string waypoint, std::string object_id, std::string observation_xml, GetObjStruct& returned_object);
     void additionalViewsCallback(const sensor_msgs::PointCloud2::ConstPtr& msg);
     void additionalViewsStatusCallback(const std_msgs::String& msg);
+    void dynamicObjectTracksCallback(const object_manager::DynamicObjectTracksConstPtr& msg);
+
 
     static CloudPtr filterGroundClusters(CloudPtr dynamic, double min_height)
     {
@@ -107,6 +112,7 @@ private:
     ros::Publisher                                                              m_PublisherDynamicClusters;
     ros::Publisher                                                              m_PublisherRequestedObjectCloud;
     ros::Publisher                                                              m_PublisherRequestedObjectImage;
+    ros::Subscriber                                                             m_SubscriberDynamicObjectTracks;
     ros::Subscriber                                                             m_SubscriberAdditionalObjectViews;
     ros::Subscriber                                                             m_SubscriberAdditionalObjectViewsStatus;
     ros::ServiceServer                                                          m_DynamicObjectsServiceServer;
@@ -163,6 +169,8 @@ ObjectManager<PointType>::ObjectManager(ros::NodeHandle nh)
     m_objectTracked = NULL;
     m_objectTrackedObservation = "";
     m_bTrackingStarted = false;
+
+    m_SubscriberDynamicObjectTracks = m_NodeHandle.subscribe("/object_learning/dynamic_object_tracks",1, &ObjectManager::dynamicObjectTracksCallback,this);
 }
 
 template <class PointType>
@@ -228,6 +236,43 @@ void ObjectManager<PointType>::additionalViewsCallback(const sensor_msgs::PointC
         ROS_ERROR_STREAM("Received an additional view when we're not viewing an object.");
     }
 
+
+}
+
+template <class PointType>
+void ObjectManager<PointType>::dynamicObjectTracksCallback(const object_manager::DynamicObjectTracksConstPtr& msg)
+{
+    if (m_objectTracked == NULL)
+    {
+        ROS_ERROR_STREAM("Received a dynamic object tracks message but a dynamic object hasn't been selected yet");
+        return;
+    }
+
+    if (m_bTrackingStarted)
+    {
+        ROS_INFO_STREAM("Received a dynamic object tracks message. Object tracked id: "<<m_objectTracked->m_label);
+        ROS_INFO_STREAM("Dynamic object tracks message contains "<<msg->poses.size()<<" poses and  "<<msg->clouds.size()<<" clouds.");
+        if (msg->poses.size() != msg->clouds.size())
+        {
+            ROS_ERROR_STREAM("The dynamic object tracks message contains an unequal number of poses and clouds. Aborting");
+            return;
+        }
+
+        for (size_t i=0; i<msg->clouds.size(); i++)
+        {
+            // cloud message
+            CloudPtr new_cloud(new Cloud());
+            pcl::fromROSMsg(msg->clouds[i], *new_cloud);
+            new_cloud->header = pcl_conversions::toPCL(msg->clouds[i].header);
+            // pose message
+            tf::Transform pose;
+            tf::transformMsgToTF(msg->poses[i],pose);
+
+            m_objectTracked->addObjectTrack(pose, new_cloud);
+        }
+    } else {
+        ROS_ERROR_STREAM("Received a dynamic object tracks message when we're not viewing an object.");
+    }
 
 }
 

--- a/object_manager/include/object_manager.h
+++ b/object_manager/include/object_manager.h
@@ -258,6 +258,16 @@ void ObjectManager<PointType>::dynamicObjectTracksCallback(const object_manager:
             return;
         }
 
+        // TESTING
+        m_objectTracked->m_bVerbose = true;
+//        SemanticRoom<PointType> aRoom = SemanticRoomXMLParser<PointType>::loadRoomFromXML(m_objectTrackedObservation,true);
+//        auto clouds = aRoom.getIntermediateClouds();
+//        auto transforms = aRoom.getIntermediateCloudTransforms();
+//        for (size_t i=0; i<clouds.size(); i++)
+//        {
+//            m_objectTracked->addObjectTrack(transforms[i], clouds[i]);
+//        }
+
         for (size_t i=0; i<msg->clouds.size(); i++)
         {
             // cloud message
@@ -268,7 +278,13 @@ void ObjectManager<PointType>::dynamicObjectTracksCallback(const object_manager:
             tf::Transform pose;
             tf::transformMsgToTF(msg->poses[i],pose);
 
-            m_objectTracked->addObjectTrack(pose, new_cloud);
+            if (new_cloud->points.size() == 0)
+            {
+                ROS_ERROR_STREAM("Provided point cloud contains 0 points. Skipping");
+                continue;
+            } else {
+                m_objectTracked->addObjectTrack(pose, new_cloud);
+            }
         }
     } else {
         ROS_ERROR_STREAM("Received a dynamic object tracks message when we're not viewing an object.");
@@ -358,6 +374,10 @@ bool ObjectManager<PointType>::getDynamicObject(std::string waypoint, std::strin
             break;
         }
     }
+    if(!found)
+    {
+        ROS_ERROR_STREAM("Object "<<object_id<<" at waypoint "<<waypoint<<" could not be found.");
+    }
     return true;
 }
 
@@ -379,6 +399,7 @@ bool ObjectManager<PointType>::getDynamicObjectServiceCallback(GetDynamicObjectS
     bool found =returnObjectMask(req.waypoint_id, req.object_id,m_waypointToSweepFileMap[req.waypoint_id], object);
     if (!found)
     {
+        ROS_ERROR_STREAM("Could not compute mask for object id "<<req.object_id);
         return true;
     }
 

--- a/object_manager/msg/DynamicObjectTracks.msg
+++ b/object_manager/msg/DynamicObjectTracks.msg
@@ -1,2 +1,2 @@
 geometry_msgs/Transform[] poses
-sensor_msgs/PointCloud[] clouds
+sensor_msgs/PointCloud2[] clouds

--- a/object_manager/msg/DynamicObjectTracks.msg
+++ b/object_manager/msg/DynamicObjectTracks.msg
@@ -1,0 +1,2 @@
+geometry_msgs/Transform[] poses
+sensor_msgs/PointCloud[] clouds

--- a/object_manager/src/dynamic_object.cpp
+++ b/object_manager/src/dynamic_object.cpp
@@ -238,3 +238,15 @@ void DynamicObject::computeVFHFeatures()
         cout<<"Computed VFH descriptor "<<endl;
     }
 }
+
+void DynamicObject::addObjectTrack(tf::Transform pose, CloudPtr cloud)
+{
+    ObjectTrack track;
+    track.pose = pose;
+    track.cloud = cloud;
+    m_vObjectTracks.push_back(track);
+    if (m_bVerbose)
+    {
+        cout<<"Added new object track. Total tracks "<<m_vObjectTracks.size()<<endl;
+    }
+}

--- a/object_manager/src/dynamic_object_xml_parser.cpp
+++ b/object_manager/src/dynamic_object_xml_parser.cpp
@@ -57,6 +57,7 @@ std::string DynamicObjectXMLParser::saveAsXML(DynamicObject::Ptr object, std::st
     xmlWriter->writeAttribute("roomRunNumber",QString::number(object->m_roomRunNumber));
     xmlWriter->writeAttribute("filename",cloud_filename.c_str());
     xmlWriter->writeAttribute("additionalViews",QString::number(object->m_noAdditionalViews));
+    xmlWriter->writeAttribute("objectTracks",QString::number(object->m_vObjectTracks.size()));
     pcl::io::savePCDFileBinary(cloud_path, *object->m_points);
 
     // save additional views
@@ -74,6 +75,16 @@ std::string DynamicObjectXMLParser::saveAsXML(DynamicObject::Ptr object, std::st
             pcl::io::savePCDFileBinary(view_path, *object->m_vAdditionalViews[i]);
         }
     }
+
+    // save object tracks
+    xmlWriter->writeStartElement("ObjectTracks");
+    for (size_t i=0; i<object->m_vObjectTracks.size(); i++)
+    {
+        stringstream ss; ss<<i;
+        string track_cloud = m_rootFolderPath + "/" + object->m_label + "_object_track_"+ss.str()+".pcd";
+        saveObjectTrackToXml(object->m_vObjectTracks[i].pose, object->m_vObjectTracks[i].cloud,xmlWriter, "ObjectTrack",track_cloud);
+    }
+    xmlWriter->writeEndElement(); // ObjectTracks
 
 
     xmlWriter->writeStartElement("Centroid");
@@ -236,6 +247,18 @@ DynamicObject::Ptr DynamicObjectXMLParser::loadFromXML(string filename, bool loa
                 boost::posix_time::ptime objectTime = boost::posix_time::time_from_string(logTime.toStdString());
                 object->m_time = objectTime;
             }
+
+            if (xmlReader->name() == "ObjectTrack")
+            {
+                bool errorReading = false;
+                DynamicObject::ObjectTrack track = readObjectTrackFromXml(xmlReader, "ObjectTrack",objectFolder.toStdString(), errorReading);
+                if (errorReading)
+                {
+                    std::cerr<<"Error while loading object track. Not adding to object."<<std::endl;
+                } else {
+                    object->addObjectTrack(track.pose, track.cloud);
+                }
+            }
         }
     }
 
@@ -245,4 +268,136 @@ DynamicObject::Ptr DynamicObjectXMLParser::loadFromXML(string filename, bool loa
     }
 
     return object;
+}
+
+
+void DynamicObjectXMLParser::saveObjectTrackToXml(tf::Transform pose, CloudPtr cloud, QXmlStreamWriter* xmlWriter, std::string nodeName, std::string cloudFilename)
+{
+    geometry_msgs::Transform msg_reg;
+    tf::transformTFToMsg(pose, msg_reg);
+
+    xmlWriter->writeStartElement(nodeName.c_str());
+    xmlWriter->writeAttribute("Trans_x",QString::number(msg_reg.translation.x));
+    xmlWriter->writeAttribute("Trans_y",QString::number(msg_reg.translation.y));
+    xmlWriter->writeAttribute("Trans_z",QString::number(msg_reg.translation.z));
+    xmlWriter->writeAttribute("Rot_w",QString::number(msg_reg.rotation.w));
+    xmlWriter->writeAttribute("Rot_x",QString::number(msg_reg.rotation.x));
+    xmlWriter->writeAttribute("Rot_y",QString::number(msg_reg.rotation.y));
+    xmlWriter->writeAttribute("Rot_z",QString::number(msg_reg.rotation.z));
+    xmlWriter->writeAttribute("Cloud_filename", cloudFilename.c_str());
+    pcl::io::savePCDFileBinary(cloudFilename, *cloud);
+
+    xmlWriter->writeEndElement();
+}
+
+DynamicObject::ObjectTrack DynamicObjectXMLParser::readObjectTrackFromXml(QXmlStreamReader* xmlReader, std::string nodeName, std::string objectFolder, bool& errorReading)
+{
+    DynamicObject::ObjectTrack toRet;
+
+    errorReading = false;
+    geometry_msgs::Transform tfmsg;
+    tf::Transform transform;
+    std::string cloud_name = "";
+
+    if (xmlReader->name() == nodeName.c_str())
+    {
+        errorReading = false;
+        QXmlStreamAttributes paramAttributes = xmlReader->attributes();
+
+        if (paramAttributes.hasAttribute("Cloud_filename"))
+        {
+            QString val = paramAttributes.value("Cloud_filename").toString();
+            cloud_name = val.toStdString();
+            std::string cloud_path = objectFolder + "/" + cloud_name;
+            pcl::PCDReader reader;
+            CloudPtr cloud (new Cloud);
+            reader.read (cloud_path, *cloud);
+            if (cloud->points.size() != 0)
+            {
+                errorReading = true;
+                ROS_ERROR("%s dynamic object track point cloud has no points. ", cloud_path.c_str());
+            } else {
+                toRet.cloud = cloud;
+            }
+        } else {
+            ROS_ERROR("%s xml node does not have the Stamp_sec attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Trans_x"))
+        {
+            QString val = paramAttributes.value("Trans_x").toString();
+            tfmsg.translation.x = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Trans_x attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Trans_y"))
+        {
+            QString val = paramAttributes.value("Trans_y").toString();
+            tfmsg.translation.y = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Trans_y attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Trans_z"))
+        {
+            QString val = paramAttributes.value("Trans_z").toString();
+            tfmsg.translation.z = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Trans_z attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Rot_w"))
+        {
+            QString val = paramAttributes.value("Rot_w").toString();
+            tfmsg.rotation.w = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Rot_w attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Rot_x"))
+        {
+            QString val = paramAttributes.value("Rot_x").toString();
+            tfmsg.rotation.x = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Rot_x attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Rot_y"))
+        {
+            QString val = paramAttributes.value("Rot_y").toString();
+            tfmsg.rotation.y = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Rot_y attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+        if (paramAttributes.hasAttribute("Rot_z"))
+        {
+            QString val = paramAttributes.value("Rot_z").toString();
+            tfmsg.rotation.z = val.toDouble();
+
+        } else {
+            ROS_ERROR("%s xml node does not have the Rot_z attribute. Cannot construct tf::StampedTransform.", xmlReader->name().toString().toStdString().c_str());
+            errorReading = true;
+        }
+
+    } else {
+        ROS_ERROR("Error while attempting to construct tf::StampedTransform from node name %s  Node expected %s",xmlReader->name().toString().toStdString().c_str(), nodeName.c_str());
+        errorReading = true;
+    }
+
+    if (!errorReading)
+    {
+        //            ROS_INFO_STREAM("No error while parsing node "<<xmlReader->name().toString().toStdString()<<"  constructing tf object ");
+        tf::transformMsgToTF(tfmsg, transform);
+        toRet.pose = transform;
+    }
+
+    return toRet;
 }

--- a/object_manager/src/load_objects_from_mongo.cpp
+++ b/object_manager/src/load_objects_from_mongo.cpp
@@ -141,12 +141,47 @@ int main(int argc, char** argv)
                             ROS_INFO_STREAM("Found "<<ss.str());
                             CloudPtr databaseCloud(new Cloud());
                             pcl::fromROSMsg(*results[0],*databaseCloud);
-                            QString cloud_name = full_room + "/"+QString("complete_cloud.pcd");
 
                             try {
                                 if (databaseCloud->points.size()>0)
                                 {
                                     parsed->m_vAdditionalViews.push_back(databaseCloud);
+                                }
+                            } catch (...)
+                            {
+
+                            }
+
+                        } else {
+                            ROS_WARN_STREAM("Found multiple matches for element named "<<ss.str());
+                        }
+
+                    } else {
+                        ROS_WARN_STREAM("Cannot find element named "<<ss.str());
+                    }
+                }
+            }
+
+            // object tracks
+            {
+                for (size_t i=0; i<parsed->m_vObjectTracks.size(); i++)
+                {
+                    stringstream ss;ss<<object_name.toStdString();ss<<"___object_track_";ss<<i;
+
+                    sensor_msgs::PointCloud2 msg_cloud;
+                    std::vector< boost::shared_ptr<sensor_msgs::PointCloud2> > results;
+
+                    if(message_store_data.queryNamed<sensor_msgs::PointCloud2>(ss.str(), results,false)) {
+                        if (results.size() == 1)
+                        {
+                            ROS_INFO_STREAM("Found "<<ss.str());
+                            CloudPtr databaseCloud(new Cloud());
+                            pcl::fromROSMsg(*results[0],*databaseCloud);
+
+                            try {
+                                if (databaseCloud->points.size()>0)
+                                {
+                                    parsed->m_vObjectTracks[i].cloud = databaseCloud;
                                 }
                             } catch (...)
                             {

--- a/semantic_map/CMakeLists.txt
+++ b/semantic_map/CMakeLists.txt
@@ -23,6 +23,11 @@ add_message_files(
   RoomObservation.msg
 )
 
+add_service_files(
+   FILES
+   ClearMetaroomService.srv
+)
+
 generate_messages(
   DEPENDENCIES
   std_msgs

--- a/semantic_map/include/semantic_map/metaroom.hpp
+++ b/semantic_map/include/semantic_map/metaroom.hpp
@@ -213,6 +213,13 @@ MetaRoomUpdateIteration<PointType>    MetaRoom<PointType>::updateMetaRoom(Semant
         ROS_INFO_STREAM("Room log name "<<aRoom.getRoomLogName());
         ROS_INFO_STREAM("Room run number "<<aRoom.getRoomRunNumber());
 //            ROS_INFO_STREAM("Room centroid "<<aRoom.getCentroid());
+
+        if (aRoom.getRoomStringId() != "")
+        {
+            this->m_sMetaroomStringId = aRoom.getRoomStringId();
+        }
+
+
         std::vector<tf::StampedTransform> roomTransforms = aRoom.getIntermediateCloudTransforms();
         std::vector<tf::StampedTransform> roomRegisteredTransforms = aRoom.getIntermediateCloudTransformsRegistered();
         if (roomRegisteredTransforms.size() != 0)
@@ -271,12 +278,6 @@ MetaRoomUpdateIteration<PointType>    MetaRoom<PointType>::updateMetaRoom(Semant
             Eigen::Matrix4f eigen_matrix(eigen_affine.matrix().cast<float>());
             this->setRoomTransform(eigen_matrix);
         }
-
-        if (aRoom.getRoomStringId() != "")
-        {
-            this->m_sMetaroomStringId = aRoom.getRoomStringId();
-        }
-
 
         MetaRoomUpdateIteration<PointType> updateIteration;
         updateIteration.roomLogName = aRoom.getRoomLogName();

--- a/semantic_map/include/semantic_map/metaroom_xml_parser.hpp
+++ b/semantic_map/include/semantic_map/metaroom_xml_parser.hpp
@@ -763,14 +763,25 @@ QString MetaRoomXMLParser<PointType>::findMetaRoomLocation(MetaRoom<PointType>* 
             } else {
                 QString savedMetaRoomXMLFile = tempMetaRoomFolder+tempMetaRoomFolderFiles[0]; // TODO for now I am assuming there is only 1 xml file in the metaroom folder. Maybe later there will be more.
                 MetaRoom<PointType> savedMetaRoom = MetaRoomXMLParser::loadMetaRoomFromXML(savedMetaRoomXMLFile.toStdString(),false);
-                double centroidDistance = pcl::distances::l2(savedMetaRoom.getCentroid(),aMetaRoom->getCentroid());
-                ROS_INFO_STREAM("Comparing with saved metaroom. Centroid distance "<<centroidDistance);
-                if (centroidDistance < ROOM_CENTROID_DISTANCE)
+                if (aMetaRoom->m_sMetaroomStringId != "")
                 {
-                    // found a matching metaroom
-                    metaRoomFolder = tempMetaRoomFolder;
-                    metaRoomFolderFound = true;
-                    break;
+                    if (savedMetaRoom.m_sMetaroomStringId == aMetaRoom->m_sMetaroomStringId)
+                    {
+                        // found a matching metaroom
+                        metaRoomFolder = tempMetaRoomFolder;
+                        metaRoomFolderFound = true;
+                        break;
+                    }
+                } else {
+                    double centroidDistance = pcl::distances::l2(savedMetaRoom.getCentroid(),aMetaRoom->getCentroid());
+                    ROS_INFO_STREAM("Comparing with saved metaroom. Centroid distance "<<centroidDistance);
+                    if (centroidDistance < ROOM_CENTROID_DISTANCE)
+                    {
+                        // found a matching metaroom
+                        metaRoomFolder = tempMetaRoomFolder;
+                        metaRoomFolderFound = true;
+                        break;
+                    }
                 }
 
                 metarooms++;

--- a/semantic_map/include/semantic_map/semantic_map_node.h
+++ b/semantic_map/include/semantic_map/semantic_map_node.h
@@ -87,6 +87,7 @@ private:
     std::map<std::string, CloudPtr>                                             m_WaypointToDynamicClusterMap;
     bool                                                                        m_bUpdateMetaroom;
     bool                                                                        m_bNewestClusters;
+    bool                                                                        m_bUseNDTRegistration;
 
 };
 
@@ -135,6 +136,16 @@ SemanticMapNode<PointType>::SemanticMapNode(ros::NodeHandle nh) : m_messageStore
     } else {
         ROS_INFO_STREAM("All the dynamic clusters will be computer (comparing with the metaroom).");
     }
+
+    m_NodeHandle.param<bool>("use_NDT_registration",m_bUseNDTRegistration,true);
+    if (m_bUseNDTRegistration)
+    {
+        ROS_INFO_STREAM("The default registration method between sweeps is NDT.");
+    } else {
+        ROS_INFO_STREAM("The default registration between sweeps will use the computed image features (and RANSAC), if available. If not available defaulting to NDT registration.");
+    }
+
+
 
     std::string statusTopic;
     m_NodeHandle.param<std::string>("status_topic",statusTopic,"/local_metric_map/status");
@@ -270,7 +281,7 @@ void SemanticMapNode<PointType>::processRoomObservation(std::string xml_file_nam
         ROS_INFO_STREAM("Initializing metaroom.");
     } else {
 
-        if ((rawPoses !=NULL) && (mr_features.size() != 0) && (room_features.size() != 0))
+        if ((!m_bUseNDTRegistration) && (rawPoses !=NULL) && (mr_features.size() != 0) && (room_features.size() != 0))
         {
             ROS_INFO_STREAM("Registering sweep using ORB features.");
             unsigned int gx = 17;

--- a/semantic_map/include/semantic_map/semantic_map_node.h
+++ b/semantic_map/include/semantic_map/semantic_map_node.h
@@ -44,7 +44,6 @@
 
 #include <strands_sweep_registration/RobotContainer.h>
 
-
 template <class PointType>
 class SemanticMapNode {
 public:
@@ -90,7 +89,6 @@ template <class PointType>
 SemanticMapNode<PointType>::SemanticMapNode(ros::NodeHandle nh) : m_messageStore(nh)
 {
     ROS_INFO_STREAM("Semantic map node initialized");
-
     m_NodeHandle = nh;
 
     m_SubscriberRoomObservation = m_NodeHandle.subscribe("/local_metric_map/room_observations",1, &SemanticMapNode::roomObservationCallback,this);
@@ -234,6 +232,7 @@ void SemanticMapNode<PointType>::processRoomObservation(std::string xml_file_nam
         {
             ROS_INFO_STREAM("No matching metaroom found. Create new metaroom.");
             metaroom =  boost::shared_ptr<MetaRoom<PointType> >(new MetaRoom<PointType>());
+            metaroom->m_sMetaroomStringId = aRoom.getRoomStringId(); // set waypoint, to figure out where to save
 
         } else {
             ROS_INFO_STREAM("Matching metaroom found. XML file: "<<matchingMetaroomXML);
@@ -443,10 +442,9 @@ void SemanticMapNode<PointType>::processRoomObservation(std::string xml_file_nam
         occlusionChecker.setSensorOrigin(metaroom->getSensorOrigin()); // since it's already transformed in the metaroom frame of ref
         auto occlusions = occlusionChecker.checkOcclusions(differenceRoomToPrevRoom,differencePrevRoomToRoom, 720 );
         *difference = *occlusions.toBeRemoved;
-
     }
 
-
+    ROS_INFO_STREAM("Raw difference "<<difference->points.size());
 
 
     if (difference->points.size() == 0)

--- a/semantic_map/include/semantic_map/semantic_map_summary_parser.h
+++ b/semantic_map/include/semantic_map/semantic_map_summary_parser.h
@@ -117,13 +117,25 @@ public:
             currentMatches.push_back(std::make_pair(allRooms[i].roomXmlFile,allRooms[i].roomLogStartTime));
             for (int j=i+1; j<allRooms.size();j++)
             {
-                double centroidDistance = pcl::distances::l2(allRooms[i].centroid,allRooms[j].centroid);
-                if (! (centroidDistance < ROOM_CENTROID_DISTANCE) )
+                if (allRooms[i].stringId !="")
                 {
-                    continue;
+                    // compare by waypoint id first
+                    if (!(allRooms[i].stringId == allRooms[j].stringId))
+                    {
+                        continue;
+                    } else {
+                        matches++;
+                        currentMatches.push_back(std::make_pair(allRooms[j].roomXmlFile,allRooms[j].roomLogStartTime));
+                    }
                 } else {
-                    matches++;
-                    currentMatches.push_back(std::make_pair(allRooms[j].roomXmlFile,allRooms[j].roomLogStartTime));
+                    double centroidDistance = pcl::distances::l2(allRooms[i].centroid,allRooms[j].centroid);
+                    if (! (centroidDistance < ROOM_CENTROID_DISTANCE) )
+                    {
+                        continue;
+                    } else {
+                        matches++;
+                        currentMatches.push_back(std::make_pair(allRooms[j].roomXmlFile,allRooms[j].roomLogStartTime));
+                    }
                 }
             }
 

--- a/semantic_map/launch/semantic_map.launch
+++ b/semantic_map/launch/semantic_map.launch
@@ -4,6 +4,8 @@
   <arg name="log_to_db"           	  default="false" />
   <arg name="update_metaroom"             default="true" />
   <arg name="machine"   	default="localhost" />
+  <arg name="use_NDT_registration"             default="true" />
+
   <arg name="user"   	default="" />
   <arg name="newest_dynamic_clusters" default="false" />
  
@@ -14,6 +16,7 @@
 	<param name="log_to_db"  type="bool" value="$(arg log_to_db)"/>
 	<param name="update_metaroom"  type="bool" value="$(arg update_metaroom)"/>
 	<param name="newest_dynamic_clusters"  type="bool" value="$(arg newest_dynamic_clusters)"/>
+	<param name="use_NDT_registration"  type="bool" value="$(arg use_NDT_registration)"/>
   </node>
 
 </launch>

--- a/semantic_map/scripts/metric_map_task_client.py
+++ b/semantic_map/scripts/metric_map_task_client.py
@@ -23,13 +23,13 @@ if __name__ == '__main__':
     try:
 
 	task = Task(start_node_id=sys.argv[1], action='ptu_pan_tilt_metric_map')
-        task_utils.add_int_argument(task, '-150')
-        task_utils.add_int_argument(task, '60')
+        task_utils.add_int_argument(task, '-160')
+        task_utils.add_int_argument(task, '20')
         task_utils.add_int_argument(task, '160')
         task_utils.add_int_argument(task, '-30')
-        task_utils.add_int_argument(task, '20')
         task_utils.add_int_argument(task, '30')
-
+        task_utils.add_int_argument(task, '30')
+	task.max_duration = rospy.Duration(60*4)
         print task
 
         # now register this with the executor

--- a/semantic_map/srv/ClearMetaroomService.srv
+++ b/semantic_map/srv/ClearMetaroomService.srv
@@ -1,0 +1,3 @@
+string[] waypoint_id
+bool initialize
+---

--- a/semantic_map_launcher/launch/semantic_map.launch
+++ b/semantic_map_launcher/launch/semantic_map.launch
@@ -2,7 +2,7 @@
 
   <arg name="save_intermediate_clouds" default="true" />
   <arg name="save_intermediate_images" default="false" />
-  <arg name="log_to_db" default="false" />
+  <arg name="log_to_db" default="true" />
   <arg name="log_objects_to_db" default="true" />
   <arg name="cleanup" default="false" />
   <arg name="cache_old_data" default="false" />

--- a/semantic_map_launcher/launch/semantic_map.launch
+++ b/semantic_map_launcher/launch/semantic_map.launch
@@ -9,6 +9,7 @@
   <arg name="max_instances" default="5" />
   <arg name="update_metaroom" default="true" />
   <arg name="newest_dynamic_clusters" default="true" />
+  <arg name="use_NDT_registration" default="true" />
 
 
   <arg name="machine" default="localhost" />
@@ -40,6 +41,7 @@
     	<arg name="machine" value="$(arg mapping_ip)"/>
 	<arg name="user" value="$(arg mapping_user)" />  
 	<arg name="newest_dynamic_clusters" value="$(arg newest_dynamic_clusters)" />  
+	<arg name="use_NDT_registration" value="$(arg use_NDT_registration)" />  
     </include>
 
     <node machine="$(arg machine)" pkg="calibrate_sweeps" type="calibrate_sweep_as" name="calibrate_sweep_as" output="screen" respawn="true"/>


### PR DESCRIPTION
- Added a service that clears and re-initializes the metarooms for a (set of) waypoint, using the latest observation. Also compute dynamic objects using the last two saved observations (if available). 
- Added a launch file parameter that allows switching between NDT and image feature registration between sweeps. 
