### PR TITLE
[dynamic_object_retrieval] Changed absolute path creation to not require that the segments exist

### DIFF
--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
@@ -164,7 +164,8 @@ struct data_summary {
         }
         if (!boost::filesystem::path(index_convex_segment_paths[0]).is_absolute()) {
             for (std::string& segment_path : index_convex_segment_paths) {
-                segment_path = boost::filesystem::canonical(segment_path, data_path).string();
+                //segment_path = boost::filesystem::canonical(segment_path, data_path).string();
+                segment_path = boost::filesystem::absolute(segment_path, data_path).string();
             }
         }
     }

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
@@ -162,7 +162,7 @@ struct data_summary {
             cereal::JSONInputArchive archive_i(in);
             archive_i(*this);
         }
-        if (!boost::filesystem::path(index_convex_segment_paths[0]).is_absolute()) {
+        if (!index_convex_segment_paths.empty() && !boost::filesystem::path(index_convex_segment_paths[0]).is_absolute()) {
             for (std::string& segment_path : index_convex_segment_paths) {
                 //segment_path = boost::filesystem::canonical(segment_path, data_path).string();
                 segment_path = boost::filesystem::absolute(segment_path, data_path).string();
@@ -172,7 +172,7 @@ struct data_summary {
 
     void save(const boost::filesystem::path& data_path)
     {
-        if (is_sub_dir(boost::filesystem::path(index_convex_segment_paths[0]), data_path)) {
+        if (!index_convex_segment_paths.empty() && is_sub_dir(boost::filesystem::path(index_convex_segment_paths[0]), data_path)) {
             for (std::string& segment_path : index_convex_segment_paths) {
                 segment_path = make_relative(boost::filesystem::path(segment_path), data_path).string();
             }


### PR DESCRIPTION
@RaresAmbrus Tested, now works also when segments have been deleted.
