### PR TITLE
[quasimodo] Integrate mongodb world_state observations and enable querying individual databases

### DIFF
--- a/dynamic_object_retrieval/benchmark/include/object_3d_benchmark/benchmark_visualization.h
+++ b/dynamic_object_retrieval/benchmark/include/object_3d_benchmark/benchmark_visualization.h
@@ -16,8 +16,8 @@ using CloudT = pcl::PointCloud<PointT>;
 namespace benchmark_retrieval {
 
 void put_text(cv::Mat& image, const std::string& text);
-cv::Mat make_image(std::vector<CloudT::Ptr>& results,  const Eigen::Matrix4f& room_transform,
-                   std::vector<boost::filesystem::path>& sweep_paths, const std::vector<std::string>& optional_text);
+std::pair<cv::Mat, std::vector<cv::Mat> > make_image(std::vector<CloudT::Ptr>& results,  const Eigen::Matrix4f& room_transform,
+                                                     std::vector<boost::filesystem::path>& sweep_paths, const std::vector<std::string>& optional_text);
 cv::Mat add_query_image(cv::Mat& results, cv::Mat& query_image, const std::string& query_label);
 
 // this will alter the look of the point clouds, but for the better I think
@@ -25,6 +25,9 @@ cv::Mat add_query_image(cv::Mat& results, cv::Mat& query_image, const std::strin
 cv::Mat make_visualization_image(cv::Mat& query_image, const std::string& query_label, std::vector<CloudT::Ptr>& clouds,
                                  std::vector<boost::filesystem::path>& sweep_paths, const std::vector<std::string>& optional_text,
                                  const Eigen::Matrix4f& T);
+cv::Mat make_visualization_image(cv::Mat& query_image, const std::string& query_label, std::vector<CloudT::Ptr>& clouds,
+                                 std::vector<boost::filesystem::path>& sweep_paths, const std::vector<std::string>& optional_text,
+                                 const Eigen::Matrix4f& T, std::vector<cv::Mat>& individual_images);
 cv::Mat make_visualization_image(CloudT::Ptr& query_cloud, cv::Mat& query_mask, const boost::filesystem::path& query_path,
                                  const Eigen::Matrix3f& K, const Eigen::Matrix4f& query_transform,
                                  const std::string& query_label, std::vector<CloudT::Ptr>& clouds,

--- a/dynamic_object_retrieval/benchmark/src/benchmark_visualization.cpp
+++ b/dynamic_object_retrieval/benchmark/src/benchmark_visualization.cpp
@@ -41,7 +41,7 @@ cv::Mat make_visualization_image(cv::Mat& query_image, const string& query_label
 {
     cv::Mat result_image;
     tie(result_image, individual_images) = make_image(clouds, T, sweep_paths, optional_text);
-    individual_images.insert(individual_images.begin(), result_image.clone());
+    individual_images.insert(individual_images.begin(), query_image.clone());
     return add_query_image(result_image, query_image, query_label);
 }
 
@@ -267,7 +267,7 @@ pair<cv::Mat, vector<cv::Mat> > make_image(std::vector<CloudT::Ptr>& results, co
     int height = 200;
 
     cv::Mat visualization = cv::Mat::zeros(height*sizes.first, width*sizes.second, CV_8UC3);
-    cv::Mat individual_images;
+    vector<cv::Mat> individual_images;
 
     int counter = 0;
     for (CloudT::Ptr& cloud : results) {

--- a/dynamic_object_retrieval/benchmark/src/benchmark_visualization.cpp
+++ b/dynamic_object_retrieval/benchmark/src/benchmark_visualization.cpp
@@ -247,7 +247,7 @@ cv::Mat render_image(CloudT::Ptr& cloud, const Eigen::Matrix4f& T, const Eigen::
 cv::Mat make_image(std::vector<CloudT::Ptr>& results, const Eigen::Matrix4f& room_transform,
                    vector<boost::filesystem::path>& sweep_paths, const std::vector<std::string>& optional_text)
 {
-    pair<int, int> sizes = make_pair(1, 10);//get_similar_sizes(results.size());
+    pair<int, int> sizes = make_pair(1, std::min(10, int(results.size())));//get_similar_sizes(results.size());
 
     int width = 200;
     int height = 200;

--- a/dynamic_object_retrieval/dynamic_object_retrieval/CMakeLists.txt
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/CMakeLists.txt
@@ -16,6 +16,9 @@ add_definitions(-std=c++11 -O3)
 # Show where to find the find package scripts
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
+set(stopwatch_dir ${CMAKE_CURRENT_SOURCE_DIR}/stopwatch)
+set(stopwatch_include_dir ${stopwatch_dir}/src)
+
 # Define the locations of the k_means_tree project
 # If using catkin, including it using catkin instead
 if (catkin_FOUND)
@@ -23,6 +26,7 @@ if (catkin_FOUND)
                         metaroom_xml_parser object_manager k_means_tree convex_segmentation)
     set(ROS_LIBRARIES ${catkin_LIBRARIES})
     include_directories(${catkin_INCLUDE_DIRS})
+    #set(stopwatch_library_dir ${CATKIN_DEVEL_PREFIX}/stopwatch/build)
 else()
     set(k_means_tree_dir ${CMAKE_CURRENT_SOURCE_DIR}/../k_means_tree)
     set(k_means_tree_library_dir ${k_means_tree_dir}/build)
@@ -57,23 +61,22 @@ else()
 
     # Define the locations of cereal serialization header files
     set(cereal_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/../k_means_tree/cereal/include)
+
+    # Only compile the stopwatch project if it's not with catkin
     include_directories(${cereal_include_dir})
+    set(stopwatch_library_dir ${stopwatch_dir}/build)
+    # Compile the stopwatch project, needed for this
+    ExternalProject_Add(stopwatch_project
+      DOWNLOAD_COMMAND ""
+      SOURCE_DIR ${stopwatch_include_dir}
+      BINARY_DIR ${stopwatch_library_dir}
+      BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
+      INSTALL_COMMAND ""
+    )
 endif()
 
 # Eh, we need to somehow build this maybe?
-set(stopwatch_dir ${CMAKE_CURRENT_SOURCE_DIR}/stopwatch)
-set(stopwatch_include_dir ${stopwatch_dir}/src)
-set(stopwatch_library_dir ${stopwatch_dir}/build)
 include_directories(${stopwatch_include_dir})
-
-# Compile the stopwatch project, needed for this
-ExternalProject_Add(stopwatch_project
-  DOWNLOAD_COMMAND ""
-  SOURCE_DIR ${stopwatch_include_dir}
-  BINARY_DIR ${stopwatch_library_dir}
-  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
-  INSTALL_COMMAND ""
-)
 
 # Find PCL
 find_package(PCL 1.6 REQUIRED COMPONENTS common io search visualization surface kdtree features surface segmentation octree filter keypoints)

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -77,10 +77,6 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
     mongodb_store::MessageStoreProxy* message_store = NULL;
 
     for (IndexT s : scores) {
-        std::cout << "1. Index: " << s.index << std::endl;
-    }
-
-    for (IndexT s : scores) {
         if (s.index >= offset) {
             std::cout << "1. Index: " << s.index << " is larger than: " << offset << std::endl;
             std::cout << "URI loading does not support noise+annotated data structure!" << std::endl;
@@ -271,10 +267,6 @@ get_retrieved_path_scores(const std::vector<grouped_vocabulary_tree<HistT, 8>::r
     std::cout << "Loading URI:s file: " << (boost::filesystem::path(summary.noise_data_path) / "vocabulary" / "segment_uris.json").string() << std::endl;
     uris.load(boost::filesystem::path(summary.noise_data_path) / "vocabulary");
     mongodb_store::MessageStoreProxy* message_store = NULL;
-
-    for (IndexT s : scores) {
-        std::cout << "1. Index: " << s.subgroup_global_indices[0] << std::endl;
-    }
 
     for (IndexT s : scores) {
         int index = s.subgroup_global_indices[0];

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -149,6 +149,12 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
             boost::shared_ptr<quasimodo_msgs::fused_world_state_object> message;
             mongo::BSONObj bson_message;
             std::tie(message, bson_message) = message_store->queryID<quasimodo_msgs::fused_world_state_object>(strs[2]);
+
+            if (message->transforms.empty()) {
+                retrieved_paths.push_back(boost::filesystem::path());
+                continue;
+            }
+
             SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
             pcl::fromROSMsg(message->surfel_cloud, *surfel_cloud);
             pcl::io::savePCDFileBinary(temp_path.string(), *surfel_cloud);
@@ -373,6 +379,12 @@ get_retrieved_path_scores(const std::vector<grouped_vocabulary_tree<HistT, 8>::r
             boost::shared_ptr<quasimodo_msgs::fused_world_state_object> message;
             mongo::BSONObj bson_message;
             std::tie(message, bson_message) = message_store->queryID<quasimodo_msgs::fused_world_state_object>(strs[2]);
+
+            if (message->transforms.empty()) {
+                path_scores.back().first.push_back(boost::filesystem::path());
+                continue;
+            }
+
             SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
             pcl::fromROSMsg(message->surfel_cloud, *surfel_cloud);
             pcl::io::savePCDFileBinary(temp_path.string(), *surfel_cloud);

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -113,15 +113,15 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
             boost::split(strs, db_uri, boost::is_any_of("/"));
 
             // how do we get the home directory correctly?
-            boost::filesystem::path temp_path = boost::filesystem::absolute(boost::filesystem::path("quasimodo/temp") / (strs[2] + ".pcd"));
+            boost::filesystem::path temp_path = boost::filesystem::absolute(boost::filesystem::path("quasimodo/temp") / strs[2] / "surfel_map.pcd");
 
-            if (boost::filesystem::exists(temp_path)) {
+            if (boost::filesystem::exists(temp_path.parent_path())) {
                 retrieved_paths.push_back(temp_path);
                 continue;
             }
 
-            if (!boost::filesystem::exists("quasimodo/temp")) {
-                boost::filesystem::create_directories("quasimodo/temp");
+            if (!boost::filesystem::exists(temp_path.parent_path())) {
+                boost::filesystem::create_directories(temp_path.parent_path());
             }
 
             boost::shared_ptr<quasimodo_msgs::fused_world_state_object> message;

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -62,15 +62,24 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
     std::cout << "Loading URI:s file: " << (boost::filesystem::path(summary.noise_data_path) / "vocabulary" / "segment_uris.json").string() << std::endl;
     uris.load(boost::filesystem::path(summary.noise_data_path) / "vocabulary");
     mongodb_store::MessageStoreProxy* message_store = NULL;
+
+    for (IndexT s : scores) {
+        std::cout << "1. Index: " << s.index << std::endl;
+    }
+
     for (IndexT s : scores) {
         if (s.index >= offset) {
+            std::cout << "1. Index: " << s.index << " is larger than: " << offset << std::endl;
             std::cout << "URI loading does not support noise+annotated data structure!" << std::endl;
+            std::cout << "Got URI: " << uris.uris[s.index] << std::endl;
             exit(-1);
         }
         std::string uri = uris.uris[s.index];
-        std::cout << "Got URI: " << uri << std::endl;
+        if (verbose) {
+            std::cout << "Got URI: " << uri << " at index: " << s.index << std::endl;
+        }
         if (uri.compare(0, 10, "mongodb://") == 0) {
-            std::string db_uri = uri.substr(7, uri.size()-7);
+            std::string db_uri = uri.substr(10, uri.size()-10);
             std::vector<std::string> strs;
             boost::split(strs, db_uri, boost::is_any_of("/"));
             std::cout << "Initializing message story proxy with database: " << strs[0] << ", collection: " << strs[1] << std::endl;
@@ -87,7 +96,9 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
         // another possibility would be to actually just write surfel_map.pcd, that should be enough?
         // the big problem is that we won't able to get any of the info in room.xml
         if (s.index >= offset) {
+            std::cout << "2. Index: " << s.index << " is larger than: " << offset << std::endl;
             std::cout << "URI loading does not support noise+annotated data structure!" << std::endl;
+            std::cout << "Got URI: " << uris.uris[s.index] << std::endl;
             exit(-1);
         }
         std::string uri = uris.uris[s.index];
@@ -97,20 +108,20 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
         else if (uri.compare(0, 10, "mongodb://") == 0) {
             // don't delete anything here, instead have a cache based on the database id:s
             // use boost split to split separate the uri into database / collection / id
-            std::string db_uri = uri.substr(7, uri.size()-7);
+            std::string db_uri = uri.substr(10, uri.size()-10);
             std::vector<std::string> strs;
             boost::split(strs, db_uri, boost::is_any_of("/"));
 
             // how do we get the home directory correctly?
-            boost::filesystem::path temp_path = boost::filesystem::path("~/.ros/quasimodo/temp") / (strs[2] + ".pcd");
+            boost::filesystem::path temp_path = boost::filesystem::absolute(boost::filesystem::path("quasimodo/temp") / (strs[2] + ".pcd"));
 
             if (boost::filesystem::exists(temp_path)) {
                 retrieved_paths.push_back(temp_path);
                 continue;
             }
 
-            if (!boost::filesystem::exists("~/.ros/quasimodo/temp")) {
-                boost::filesystem::create_directories("~/.ros/quasimodo/temp");
+            if (!boost::filesystem::exists("quasimodo/temp")) {
+                boost::filesystem::create_directories("quasimodo/temp");
             }
 
             boost::shared_ptr<quasimodo_msgs::fused_world_state_object> message;

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -55,7 +55,8 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
     ros::NodeHandle n("/dynamic_retrieval");
     size_t offset = summary.nbr_noise_segments;
     segment_uris uris;
-    uris.load(boost::filesystem::path(summary.noise_data_path));
+    std::cout << "Loading URI:s file: " << (boost::filesystem::path(summary.noise_data_path) / "vocabulary" / "segment_uris.json").string() << std::endl;
+    uris.load(boost::filesystem::path(summary.noise_data_path) / "vocabulary");
     mongodb_store::MessageStoreProxy* message_store = NULL;
     for (IndexT s : scores) {
         if (s.index >= offset) {
@@ -63,6 +64,7 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
             exit(-1);
         }
         std::string uri = uris.uris[s.index];
+        std::cout << "Got URI: " << uri << std::endl;
         if (uri.compare(0, 10, "mongodb://") == 0) {
             std::string db_uri = uri.substr(7, uri.size()-7);
             std::vector<std::string> strs;

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -116,7 +116,7 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
             boost::filesystem::path temp_path = boost::filesystem::absolute(boost::filesystem::path("quasimodo/temp") / strs[2] / "surfel_map.pcd");
 
             if (boost::filesystem::exists(temp_path.parent_path())) {
-                retrieved_paths.push_back(temp_path);
+                retrieved_paths.push_back(temp_path.parent_path() / "convex_segments" / "segment.pcd");
                 continue;
             }
 

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/dynamic_retrieval.h
@@ -122,6 +122,7 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
 
             if (!boost::filesystem::exists(temp_path.parent_path())) {
                 boost::filesystem::create_directories(temp_path.parent_path());
+                boost::filesystem::create_directory(temp_path.parent_path() / "convex_segments");
             }
 
             boost::shared_ptr<quasimodo_msgs::fused_world_state_object> message;
@@ -130,7 +131,8 @@ std::vector<boost::filesystem::path> get_retrieved_paths(const std::vector<Index
             SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
             pcl::fromROSMsg(message->surfel_cloud, *surfel_cloud);
             pcl::io::savePCDFileBinary(temp_path.string(), *surfel_cloud);
-            retrieved_paths.push_back(temp_path);
+            pcl::io::savePCDFileBinary((temp_path.parent_path() / "convex_segments" / "segment.pcd").string(), *surfel_cloud);
+            retrieved_paths.push_back(temp_path.parent_path() / "convex_segments" / "segment.pcd");
 
             // [0] - database, [1] - collection, [2] - mongodb object id
 

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
@@ -85,6 +85,8 @@ struct vocabulary_summary {
     size_t max_training_features;
     size_t max_append_features;
 
+    std::string last_updated; // string for checking last update, used to know when to reload
+
     void load(const boost::filesystem::path& data_path)
     {
         std::ifstream in((data_path / boost::filesystem::path("vocabulary_summary.json")).string());
@@ -133,7 +135,8 @@ struct vocabulary_summary {
                 cereal::make_nvp("vocabulary_tree_size", vocabulary_tree_size),
                 cereal::make_nvp("min_segment_features", min_segment_features),
                 cereal::make_nvp("max_training_features", max_training_features),
-                cereal::make_nvp("max_append_features", max_append_features));
+                cereal::make_nvp("max_append_features", max_append_features),
+                cereal::make_nvp("last_updated", last_updated));
     }
 
     vocabulary_summary() : vocabulary_type("standard"), subsegment_type(""), noise_data_path(""), annotated_data_path(""), nbr_noise_segments(0), nbr_annotated_segments(0),

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/dynamic_object_retrieval/summary_types.h
@@ -242,7 +242,7 @@ struct segment_uris {
 
     void load(const boost::filesystem::path& data_path)
     {
-        std::ifstream in((data_path / boost::filesystem::path(vocabulary) / boost::filesystem::path("segment_uris.json")).string());
+        std::ifstream in((data_path / boost::filesystem::path("segment_uris.json")).string());
         {
             cereal::JSONInputArchive archive_i(in);
             archive_i(*this);
@@ -253,7 +253,8 @@ struct segment_uris {
         }
         */
 
-        if (!uris.empty() && !boost::filesystem::path(index_convex_segment_paths[0]).is_absolute()) {
+        // we can actually assume that 0 is a file since the first ones are used to train the vocabulary
+        if (!uris.empty() && !boost::filesystem::path(uris[0].substr(7, uris[0].size()-7)).is_absolute()) {
             for (std::string& segment_path : uris) {
                 //segment_path = boost::filesystem::canonical(segment_path, data_path).string();
                 //HMMM, this will start with a slash?
@@ -275,7 +276,8 @@ struct segment_uris {
         }
         */
 
-        if (!uris.empty() && is_sub_dir(boost::filesystem::path(index_convex_segment_paths[0]), data_path.parent_path())) {
+        // we can actually assume that 0 is a file since the first ones are used to train the vocabulary
+        if (!uris.empty() && is_sub_dir(boost::filesystem::path(uris[0].substr(7, uris[0].size()-7)), data_path.parent_path())) {
             for (std::string& segment_path : uris) {
                 if (segment_path.compare(0, 7, "file://") == 0) {
                     segment_path = std::string("file://") + make_relative(boost::filesystem::path(segment_path.substr(7, segment_path.size()-7)), data_path.parent_path()).string();

--- a/dynamic_object_retrieval/dynamic_object_retrieval/include/eigen_cereal/eigen_cereal.h
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/include/eigen_cereal/eigen_cereal.h
@@ -3,11 +3,14 @@
 
 #include <cereal/cereal.hpp>
 #include <cereal/archives/binary.hpp>
-#include <Eigen/Dense>
+#include <cereal/types/vector.hpp>
+#include <eigen3/Eigen/Dense>
 #include <fstream>
 
 namespace cereal
 {
+
+// for binary serialization
 template <class Archive, class _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols> inline
 typename std::enable_if<traits::is_output_serializable<BinaryData<_Scalar>, Archive>::value, void>::type
 save(Archive & ar, Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> const & m)
@@ -30,6 +33,49 @@ load(Archive & ar, Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _Max
     m.resize(rows, cols);
     ar(binary_data(m.data(), static_cast<std::size_t>(rows * cols * sizeof(_Scalar))));
 }
+
+// for json serialization
+template <class Archive, class _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols> inline
+typename std::enable_if<!traits::is_output_serializable<BinaryData<_Scalar>, Archive>::value, void>::type
+save(Archive & ar, Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> const & m)
+{
+    int32_t rows = m.rows();
+    int32_t cols = m.cols();
+    ar(rows);
+    ar(cols);
+
+    std::vector<std::vector<_Scalar> > vec(rows);
+    for (int i = 0; i < rows; i++) {
+        vec[i].resize(cols);
+        for (int j = 0; j < cols; j++) {
+            vec[i][j] = m(i, j);
+        }
+    }
+
+    ar(vec);
+}
+
+template <class Archive, class _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols> inline
+typename std::enable_if<!traits::is_input_serializable<BinaryData<_Scalar>, Archive>::value, void>::type
+load(Archive & ar, Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & m)
+{
+    int32_t rows;
+    int32_t cols;
+    ar(rows);
+    ar(cols);
+    std::vector<std::vector<_Scalar> > vec;
+    ar(vec);
+
+    m.resize(rows, cols);
+
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            m(i, j) = vec[i][j];
+        }
+    }
+
+}
+
 }
 
 #endif // EIGEN_CEREAL_H

--- a/dynamic_object_retrieval/dynamic_object_retrieval/src/extract_surfel_features.cpp
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/src/extract_surfel_features.cpp
@@ -144,8 +144,6 @@ void compute_features(HistCloudT::Ptr& features, CloudT::Ptr& keypoints, CloudT:
     for (size_t i = 0; i < pfhrgb_cloud.size(); ++i) {
         std::copy(pfhrgb_cloud.at(i).histogram, pfhrgb_cloud.at(i).histogram+N, features->at(i).histogram);
     }
-
-    std::cout << "Number of features: " << pfhrgb_cloud.size() << std::endl;
 }
 
 NormalCloudT::Ptr compute_surfel_normals(SurfelCloudT::Ptr& surfel_cloud, CloudT::Ptr& segment)

--- a/dynamic_object_retrieval/dynamic_object_retrieval/stopwatch/README.md
+++ b/dynamic_object_retrieval/dynamic_object_retrieval/stopwatch/README.md
@@ -1,9 +1,97 @@
+This whole directory is a subtree of https://github.com/mp3guy/Stopwatch .
+As such, it is created by Thomas Whelan et al. (https://github.com/mp3guy) without
+any changes by us. The code is re-distributed here to be able to use it within the larger package structure.
+
+Since some of the code is attributed to the b-human code release, we include the following license,
+which applies to those parts:
+
+LICENSE
+------------------------------------------------------------------
+Copyright (c) 2016 B-Human.  All rights reserved.
+
+
+Preamble: B-Human releases most of the software it uses at RoboCup
+competitions to allow teams participating in the Standard Platform
+League that do not have the resources to develop a complete robot
+soccer system on their own, but still have important contributions
+to make to the goals of RoboCup. We intend to enable such teams to
+benchmark their own scientific approaches in RoboCup competitions.
+We also hope that the scientific community will benefit from their
+work through the publication of their findings.
+A second reason for B-Human releasing its code is that source code
+is the most solid documentation of how problems were actually
+solved.
+
+
+Parts of this distribution were not developed by B-Human.
+This license doesn't apply to these parts, the rights of the
+copyright owners remain.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. The end-user documentation included with the redistribution, if
+   any, must include the following acknowledgment:
+   "This product includes software developed by B-Human
+    (http://www.b-human.de)."
+   Alternately, this acknowledgment may appear in the software
+   itself, if and wherever such third-party acknowledgments
+   normally appear.
+
+4. If the source code or parts of the source code shall be used
+   for a RoboCup competition, the competing program must differ in
+   at least multiple major parts from the original distribution.
+   "Major parts" means own contributions to the RoboCup goal, which
+   are potentially publishable and usually manifest themselves as
+   new modules (i.e. source code) and not just as a parameterization
+   of existing technology (e.g. walking parameters, kicks, behavior
+   options).
+
+5. For each B-Human code release from which parts are used in a
+   RoboCup competition, the usage shall be announced in the SPL
+   mailing list (currently robocup-nao@cc.gatech.edu) one month
+   before the first competition in which you are using it. The
+   announcement shall name which parts of this code are used.
+   It shall also contain a description of the own contribution
+   that addresses the criterions mentioned above.
+
+6. If you are using this source code or parts of this source code
+   and happen to meet members of B-Human at a RoboCup competition,
+   please provide these members with a few bottles of your favorite
+   beer.
+
+7. Bug fixes regarding existing code shall be sent back to B-Human via
+   GitHub pull request (https://github.com/bhuman).
+
+
+THIS SOFTWARE IS PROVIDED BY B-HUMAN ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+B-HUMAN NOR ITS MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+------------------------------------------------------------------
+
 Stopwatch
 =========
 
 Easy to use simple benchmarking tool.
 
-Sends UDP packets to localhost, which StopwatchViewer receives and displays stats on, including plots (credit to [Fiachra Matthews](http://www.linkedin.com/pub/fiachra-matthews/17/48b/a12) here). 
+Sends UDP packets to localhost, which StopwatchViewer receives and displays stats on, including plots (credit to [Fiachra Matthews](http://www.linkedin.com/pub/fiachra-matthews/17/48b/a12) here).
 
 StopwatchViewer needs Qt4 to build. Simply include Stopwatch.h in whatever code you want to benchmark and use as such;
 
@@ -17,7 +105,7 @@ int main(int argc, char *argv[])
   //This stops duplicate timings on multiple runs
   Stopwatch::getInstance().setCustomSignature(32434);
 
-  STOPWATCH("Timing1", 
+  STOPWATCH("Timing1",
 
   if(argc >= 1)
   {
@@ -41,9 +129,9 @@ int main(int argc, char *argv[])
 }
 ```
 
-Then just watch the stats in StopwatchViewer. 
+Then just watch the stats in StopwatchViewer.
 
-Uses some code from the B-Human code release (http://www.b-human.de/). 
+Uses some code from the B-Human code release (http://www.b-human.de/).
 
 <p align="center">
   <img src="http://mp3guy.github.io/img/Stopwatch.png" alt="Stopwatch"/>

--- a/dynamic_object_retrieval/k_means_tree/impl/vocabulary_tree.hpp
+++ b/dynamic_object_retrieval/k_means_tree/impl/vocabulary_tree.hpp
@@ -299,6 +299,7 @@ void vocabulary_tree<Point, K>::source_freqs_for_node(std::map<int, int>& source
     }
 }
 
+// we should make some const here to make clear what happens
 template <typename Point, size_t K>
 double vocabulary_tree<Point, K>::compute_min_combined_dist(vector<int>& included_indices, CloudPtrT& cloud, vector<vocabulary_vector>& smaller_freqs,
                                                             set<pair<int, int> >& adjacencies, map<node*, int>& mapping, map<int, node*>& inverse_mapping, int hint) // TODO: const

--- a/dynamic_object_retrieval/k_means_tree/impl/vocabulary_tree.hpp
+++ b/dynamic_object_retrieval/k_means_tree/impl/vocabulary_tree.hpp
@@ -839,3 +839,19 @@ void vocabulary_tree<Point, K>::load(Archive& archive)
     cout << "Finished loading vocabulary_tree" << endl;
 }
 */
+
+template <typename Point, size_t K>
+double vocabulary_tree<Point, K>::compute_distance(const std::map<node*, double>& vec1, double norm1,
+                                                   const std::map<node*, double>& vec2, double norm2) const
+{
+    double score = 0.0;
+    for (const pair<node* const, double>& n : vec1) {
+        if (vec2.count(n.first) == 0) {
+            continue;
+        }
+        // actually we don't need to check the depth of the node since that is already handled by compute_query_vector: GREAT!
+        score += std::min(n.second, vec2.at(n.first));
+    }
+    score = 1.0 - score/std::max(norm1, norm2);
+    return score;
+}

--- a/dynamic_object_retrieval/k_means_tree/include/vocabulary_tree/vocabulary_tree.h
+++ b/dynamic_object_retrieval/k_means_tree/include/vocabulary_tree/vocabulary_tree.h
@@ -76,7 +76,6 @@ protected:
 
     double pexp(const double v) const;
     double proot(const double v) const;
-    double compute_query_vector(std::map<node*, double>& query_id_freqs, CloudPtrT& query_cloud);
     void compute_query_vector(std::map<node*, int>& query_id_freqs, CloudPtrT& query_cloud);
     double compute_query_vector(std::map<node*, std::pair<double, int> >& query_id_freqs, CloudPtrT& query_cloud);
     void source_freqs_for_node(std::map<int, int>& source_id_freqs, node* n) const;
@@ -128,6 +127,9 @@ public:
     double compute_query_index_vector(std::map<int, double>& query_index_freqs, CloudPtrT& query_cloud, std::map<node*, int>& mapping);
     void compute_query_index_vector(std::map<int, int>& query_index_freqs, CloudPtrT& query_cloud, std::map<node*, int>& mapping);
     vocabulary_vector compute_query_index_vector(CloudPtrT& query_cloud, std::map<node *, int> &mapping);
+
+    double compute_query_vector(std::map<node*, double>& query_id_freqs, CloudPtrT& query_cloud);
+    double compute_distance(const std::map<node*, double>& vec1, double norm1, const std::map<node*, double>& vec2, double norm2) const;
 
     /*
     template <class Archive> void save(Archive& archive) const;

--- a/dynamic_object_retrieval/tools/src/create_convex_surfels.cpp
+++ b/dynamic_object_retrieval/tools/src/create_convex_surfels.cpp
@@ -3,6 +3,8 @@
 #include "retrieval_tools/surfel_type.h"
 #include <pcl/kdtree/flann.h>
 #include <pcl/kdtree/impl/kdtree_flann.hpp>
+#include <stdlib.h>
+#include <time.h>
 
 using PointT = pcl::PointXYZRGB;
 using CloudT = pcl::PointCloud<PointT>;
@@ -37,7 +39,26 @@ int main(int argc, char** argv)
         {217,217,217},
         {188,128,189},
         {204,235,197},
-        {255,237,111}
+        {255,237,111},
+        {255, 179, 0},
+        {128, 62, 117},
+        {255, 104, 0},
+        {166, 189, 215},
+        {193, 0, 32},
+        {206, 162, 98},
+        {0, 125, 52},
+        {246, 118, 142},
+        {0, 83, 138},
+        {255, 122, 92},
+        {83, 55, 122},
+        {255, 142, 0},
+        {179, 40, 81},
+        {244, 200, 0},
+        {127, 24, 13},
+        {147, 170, 0},
+        {89, 51, 21},
+        {241, 58, 19},
+        {35, 44, 22}
     };
 
     if (argc < 2) {
@@ -61,12 +82,16 @@ int main(int argc, char** argv)
 
     cout << "Analyzing convex segments..." << endl;
 
+    srand(time(NULL));
+    size_t modulo = rand() % 44;
+
     SurfelCloudT::Ptr colored_cloud(new SurfelCloudT);
     for (auto tup : dynamic_object_retrieval::zip(segments, indices)) {
         // here it seems like we're gonna have to wrap our own solution by wrapping two octrees (or voxelgrids?)
         CloudT::Ptr c;
         size_t index;
         tie(c, index) = tup;
+        index += modulo;
 
         // now, associate each point in segment with a surfel in the surfel cloud!
         for (const PointT& p : c->points) {
@@ -83,9 +108,9 @@ int main(int argc, char** argv)
             }
             SurfelT q = surfel_cloud->at(indices[0]);
             uint8_t* rgb = (uint8_t*)(&q.rgba);
-            rgb[2] = colormap[index % 24][0];
-            rgb[1] = colormap[index % 24][1];
-            rgb[0] = colormap[index % 24][2];
+            rgb[2] = colormap[index % 44][0];
+            rgb[1] = colormap[index % 44][1];
+            rgb[0] = colormap[index % 44][2];
             colored_cloud->push_back(q);
         }
     }

--- a/quasimodo/quasimodo_brain/CMakeLists.txt
+++ b/quasimodo/quasimodo_brain/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(quasimodo_brain)
 
-find_package(catkin REQUIRED COMPONENTS roscpp soma2_msgs soma_manager quasimodo_msgs quasimodo_models message_runtime pcl_ros metaroom_xml_parser eigen_conversions cv_bridge)
+find_package(catkin REQUIRED COMPONENTS roscpp soma_msgs soma_manager quasimodo_msgs quasimodo_models message_runtime pcl_ros metaroom_xml_parser eigen_conversions cv_bridge)
 
 set(CMAKE_CXX_FLAGS "-O4 -g -pg -Wunknown-pragmas -Wno-unknown-pragmas -Wsign-compare -fPIC -std=c++0x -o popcnt -mssse3")
 

--- a/quasimodo/quasimodo_brain/package.xml
+++ b/quasimodo/quasimodo_brain/package.xml
@@ -51,7 +51,7 @@
   <build_depend>libqt4-dev</build_depend>
   <build_depend>libceres-dev</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>soma2_msgs</build_depend>
+  <build_depend>soma_msgs</build_depend>
   <build_depend>soma_manager</build_depend>
   <build_depend>message_runtime</build_depend>
   <build_depend>eigen_conversions</build_depend>
@@ -66,7 +66,7 @@
   <run_depend>libqt4</run_depend>
   <run_depend>libceres-dev</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>soma2_msgs</run_depend>
+  <run_depend>soma_msgs</run_depend>
   <run_depend>soma_manager</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>eigen_conversions</run_depend>

--- a/quasimodo/quasimodo_brain/src/massregPCD.cpp
+++ b/quasimodo/quasimodo_brain/src/massregPCD.cpp
@@ -15,9 +15,9 @@
 #include "quasimodo_msgs/retrieval_query_result.h"
 #include "quasimodo_msgs/retrieval_query.h"
 #include "quasimodo_msgs/retrieval_result.h"
-#include "soma2_msgs/SOMA2Object.h"
+#include "soma_msgs/SOMAObject.h"
 
-#include "soma_manager/SOMA2InsertObjs.h"
+#include "soma_manager/SOMAInsertObjs.h"
 
 //#include "modelupdater/ModelUpdater.h"
 //#include "/home/johane/catkin_ws_dyn/src/quasimodo_models/include/modelupdater/ModelUpdater.h"

--- a/quasimodo/quasimodo_brain/src/modelserver.cpp
+++ b/quasimodo/quasimodo_brain/src/modelserver.cpp
@@ -15,9 +15,9 @@
 #include "quasimodo_msgs/retrieval_query_result.h"
 #include "quasimodo_msgs/retrieval_query.h"
 #include "quasimodo_msgs/retrieval_result.h"
-#include "soma2_msgs/SOMA2Object.h"
+#include "soma_msgs/SOMAObject.h"
 
-#include "soma_manager/SOMA2InsertObjs.h"
+#include "soma_manager/SOMAInsertObjs.h"
 
 //#include "modelupdater/ModelUpdater.h"
 //#include "/home/johane/catkin_ws_dyn/src/quasimodo_models/include/modelupdater/ModelUpdater.h"
@@ -73,7 +73,7 @@ ros::Publisher model_pcd_pub;
 ros::Publisher database_pcd_pub;
 ros::Publisher chatter_pub;
 
-ros::ServiceClient soma2add;
+ros::ServiceClient soma_add;
 
 double occlusion_penalty = 15;
 double massreg_timeout = 60;
@@ -247,10 +247,10 @@ quasimodo_msgs::model getModelMSG(reglib::Model * model){
 	return msg;
 }
 
-std::vector<soma2_msgs::SOMA2Object> getSOMA2ObjectMSGs(reglib::Model * model){
-	std::vector<soma2_msgs::SOMA2Object> msgs;
+std::vector<soma_msgs::SOMAObject> getSOMA2ObjectMSGs(reglib::Model * model){
+	std::vector<soma_msgs::SOMAObject> msgs;
 	for(unsigned int i = 0; i < model->frames.size(); i++){
-		soma2_msgs::SOMA2Object msg;
+		soma_msgs::SOMAObject msg;
 		char buf [1024];
 		sprintf(buf,"id_%i_%i",int(model->id),int(model->frames[i]->id));
 		msg.id				= std::string(buf);
@@ -346,17 +346,17 @@ std::vector<soma2_msgs::SOMA2Object> getSOMA2ObjectMSGs(reglib::Model * model){
 }
 
 void publishModel(reglib::Model * model){
-	//	std::vector<soma2_msgs::SOMA2Object> somamsgs = getSOMA2ObjectMSGs(model);
-	soma_manager::SOMA2InsertObjs objs;
+	//	std::vector<soma_msgs::SOMAObject> somamsgs = getSOMA2ObjectMSGs(model);
+	soma_manager::SOMAInsertObjs objs;
 	objs.request.objects = getSOMA2ObjectMSGs(model);
-	if (soma2add.call(objs)){//Add frame to model server
+	if (soma_add.call(objs)){//Add frame to model server
 		////			int frame_id = ifsrv.response.frame_id;
-	}else{ROS_ERROR("Failed to call service soma2add");}
+	}else{ROS_ERROR("Failed to call service soma_add");}
 
 	//	for(int i = 0; i < somamsgs.size(); i++){
-	//		if (soma2add.call(somamsgs[i])){//Add frame to model server
+	//		if (soma_add.call(somamsgs[i])){//Add frame to model server
 	////			int frame_id = ifsrv.response.frame_id;
-	//		 }else{ROS_ERROR("Failed to call service soma2add");}
+	//		 }else{ROS_ERROR("Failed to call service soma_add");}
 	//	 }
 }
 
@@ -902,8 +902,8 @@ int main(int argc, char **argv){
 	ros::ServiceServer service4 = n.advertiseService("get_model", getModel);
 	ROS_INFO("Ready to add use get_model.");
 
-	soma2add = n.serviceClient<soma_manager::SOMA2InsertObjs>(		"soma2/insert_objs");
-	ROS_INFO("Ready to add use soma2add.");
+	soma_add = n.serviceClient<soma_manager::SOMAInsertObjs>("soma/insert_objs");
+	ROS_INFO("Ready to add use soma_add.");
 
 	ros::Subscriber sub = n.subscribe("/retrieval_result", 1, retrievalCallback);
 	ROS_INFO("Ready to add recieve search results.");

--- a/quasimodo/quasimodo_conversions/CMakeLists.txt
+++ b/quasimodo/quasimodo_conversions/CMakeLists.txt
@@ -6,10 +6,17 @@ add_definitions(-std=c++11)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp quasimodo_msgs soma_llsd_msgs mongodb_store)
+find_package(catkin REQUIRED COMPONENTS roscpp quasimodo_msgs soma_llsd_msgs mongodb_store pcl_ros cv_bridge eigen_conversions tf_conversions)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
+
+# Find PCL
+find_package(PCL 1.6 REQUIRED COMPONENTS common io search visualization surface kdtree features surface segmentation octree filter keypoints)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+find_package(OpenCV REQUIRED)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -131,6 +138,8 @@ add_dependencies(conversions ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORT
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(conversions
+  ${OpenCV_LIBS}
+  ${PCL_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 

--- a/quasimodo/quasimodo_conversions/CMakeLists.txt
+++ b/quasimodo/quasimodo_conversions/CMakeLists.txt
@@ -1,0 +1,183 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(quasimodo_conversions)
+
+add_definitions(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS roscpp quasimodo_msgs soma_llsd_msgs mongodb_store)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES conversions
+  CATKIN_DEPENDS quasimodo_msgs soma_llsd_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+## Declare a C++ library
+add_library(conversions
+  src/${PROJECT_NAME}/conversions.cpp include/${PROJECT_NAME}/conversions.h
+)
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+add_dependencies(conversions ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+# add_executable(quasimodo_conversions_node src/quasimodo_conversions_node.cpp)
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(quasimodo_conversions_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(conversions
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS quasimodo_conversions quasimodo_conversions_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_quasimodo_conversions.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
+++ b/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
@@ -1,0 +1,20 @@
+#ifndef QUASIMODO_CONVERSIONS_H
+#define QUASIMODO_CONVERSIONS_H
+
+#include <soma_llsd_msgs/Segment.h>
+#include <soma_llsd_msgs/Observation.h>
+#include <soma_llsd_msgs/Scene.h>
+#include <quasimodo_msgs/model.h>
+#include <quasimodo_msgs/rgbd_frame.h>
+#include <ros/ros.h>
+
+namespace quasimodo_conversions {
+
+void model_to_soma_segment(ros::NodeHandle& n, const quasimodo_msgs::model& model, soma_llsd_msgs::Segment& segment);
+void soma_segment_to_model(ros::NodeHandle& n, const soma_llsd_msgs::Segment& segment, quasimodo_msgs::model& model);
+void soma_observation_to_frame(ros::NodeHandle& n, const soma_llsd_msgs::Observation& obs, quasimodo_msgs::rgbd_frame& frame);
+void frame_to_soma_observation(ros::NodeHandle& n, const quasimodo_msgs::rgbd_frame& frame, soma_llsd_msgs::Observation& obs);
+
+} // namespace quasimodo_conversions
+
+#endif // QUASIMODO_CONVERSIONS_H

--- a/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
+++ b/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
@@ -8,12 +8,21 @@
 #include <quasimodo_msgs/rgbd_frame.h>
 #include <ros/ros.h>
 
+#include <opencv2/opencv.hpp>
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+
 namespace quasimodo_conversions {
 
 void model_to_soma_segment(ros::NodeHandle& n, const quasimodo_msgs::model& model, soma_llsd_msgs::Segment& segment);
 void soma_segment_to_model(ros::NodeHandle& n, const soma_llsd_msgs::Segment& segment, quasimodo_msgs::model& model);
 void soma_observation_to_frame(ros::NodeHandle& n, const soma_llsd_msgs::Observation& obs, quasimodo_msgs::rgbd_frame& frame);
 void frame_to_soma_observation(ros::NodeHandle& n, const quasimodo_msgs::rgbd_frame& frame, soma_llsd_msgs::Observation& obs);
+void raw_frames_to_soma_scene(const cv::Mat& rgb, const cv::Mat& depth,
+                              const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& cloud,
+                              const Eigen::Matrix4d& pose, const Eigen::Matrix3d& K,
+                              const std::string& waypoint, const std::string episode_id,
+                              soma_llsd_msgs::Scene& scene);
 
 } // namespace quasimodo_conversions
 

--- a/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
+++ b/quasimodo/quasimodo_conversions/include/quasimodo_conversions/conversions.h
@@ -18,11 +18,13 @@ void model_to_soma_segment(ros::NodeHandle& n, const quasimodo_msgs::model& mode
 void soma_segment_to_model(ros::NodeHandle& n, const soma_llsd_msgs::Segment& segment, quasimodo_msgs::model& model);
 void soma_observation_to_frame(ros::NodeHandle& n, const soma_llsd_msgs::Observation& obs, quasimodo_msgs::rgbd_frame& frame);
 void frame_to_soma_observation(ros::NodeHandle& n, const quasimodo_msgs::rgbd_frame& frame, soma_llsd_msgs::Observation& obs);
-void raw_frames_to_soma_scene(const cv::Mat& rgb, const cv::Mat& depth,
+void raw_frames_to_soma_scene(ros::NodeHandle& n, const cv::Mat& rgb, const cv::Mat& depth,
                               const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& cloud,
                               const Eigen::Matrix4d& pose, const Eigen::Matrix3d& K,
                               const std::string& waypoint, const std::string episode_id,
                               soma_llsd_msgs::Scene& scene);
+void add_masks_to_soma_segment(ros::NodeHandle& n, std::vector<std::string>& scene_ids, std::vector<cv::Mat>& masks,
+                               std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d> >& poses, soma_llsd_msgs::Segment& segment);
 
 } // namespace quasimodo_conversions
 

--- a/quasimodo/quasimodo_conversions/package.xml
+++ b/quasimodo/quasimodo_conversions/package.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<package>
+  <name>quasimodo_conversions</name>
+  <version>0.0.0</version>
+  <description>The quasimodo_conversions package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/quasimodo_conversions</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>quasimodo_msgs</build_depend>
+  <build_depend>soma_llsd_msgs</build_depend>
+  <run_depend>quasimodo_msgs</run_depend>
+  <run_depend>soma_llsd_msgs</run_depend>
+  
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/quasimodo/quasimodo_conversions/src/quasimodo_conversions/conversions.cpp
+++ b/quasimodo/quasimodo_conversions/src/quasimodo_conversions/conversions.cpp
@@ -2,7 +2,37 @@
 #include <soma_llsd/GetScene.h>
 #include <soma_llsd/InsertScene.h>
 
+#include <pcl_ros/point_cloud.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <tf_conversions/tf_eigen.h>
+#include <eigen_conversions/eigen_msg.h>
+
 namespace quasimodo_conversions {
+
+void convert_to_img_msg(const cv::Mat& cv_image, sensor_msgs::Image& ros_image)
+{
+    cv_bridge::CvImagePtr cv_pub_ptr(new cv_bridge::CvImage);
+    cv_pub_ptr->image = cv_image;
+    cv_pub_ptr->encoding = "bgr8";
+    ros_image = *cv_pub_ptr->toImageMsg();
+}
+
+void convert_to_depth_msg(const cv::Mat& cv_image, sensor_msgs::Image& ros_image)
+{
+    cv_bridge::CvImagePtr cv_pub_ptr(new cv_bridge::CvImage);
+    cv_pub_ptr->image = cv_image;
+    cv_pub_ptr->encoding = "mono16";
+    ros_image = *cv_pub_ptr->toImageMsg();
+}
+
+void convert_to_mask_msg(const cv::Mat& cv_image, sensor_msgs::Image& ros_image)
+{
+    cv_bridge::CvImagePtr cv_pub_ptr(new cv_bridge::CvImage);
+    cv_pub_ptr->image = cv_image;
+    cv_pub_ptr->encoding = "mono8";
+    ros_image = *cv_pub_ptr->toImageMsg();
+}
 
 void model_to_soma_segment(ros::NodeHandle& n, const quasimodo_msgs::model& model, soma_llsd_msgs::Segment& segment)
 {
@@ -131,6 +161,55 @@ void soma_observation_to_frame(ros::NodeHandle& n, const soma_llsd_msgs::Observa
     //frame.camera = // see above
     frame.frame_id = std::stoi(obs.id);
     frame.pose = obs.pose; // not good actually but whatevs
+}
+
+//string episode_id
+//string waypoint
+//string meta_data
+//uint32 timestamp
+
+//tf/tfMessage transform
+//sensor_msgs/PointCloud2 cloud
+//sensor_msgs/Image rgb_img
+//sensor_msgs/Image depth_img
+//sensor_msgs/CameraInfo camera_info
+//geometry_msgs/Pose robot_pose
+//---
+//bool result
+//soma_llsd_msgs/Scene response
+
+// ### response has id field! ###
+
+void raw_frames_to_soma_scene(const cv::Mat& rgb, const cv::Mat& depth,
+                              const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& cloud,
+                              const Eigen::Matrix4d& pose, const Eigen::Matrix3d& K,
+                              const std::string& waypoint, const std::string episode_id,
+                              soma_llsd_msgs::Scene& scene)
+{
+    convert_to_img_msg(rgb, scene.rgb_img);
+    convert_to_depth_msg(depth, scene.depth_img);
+    pcl::toROSMsg(*cloud, scene.cloud);
+    tf::poseEigenToMsg(Eigen::Affine3d(pose), scene.robot_pose);
+    sensor_msgs::CameraInfo info;
+    info.K.at(0) = K(0, 0);
+    info.K.at(1) = K(0, 1);
+    info.K.at(2) = K(0, 2);
+    info.K.at(3) = K(1, 0);
+    info.K.at(4) = K(1, 1);
+    info.K.at(5) = K(1, 2);
+    info.K.at(8) = K(2, 2);
+
+    info.P.at(0) = K(0, 0);
+    info.P.at(1) = K(0, 1);
+    info.P.at(2) = K(0, 2);
+    info.P.at(4) = K(1, 0);
+    info.P.at(5) = K(1, 1);
+    info.P.at(6) = K(1, 2);
+    info.P.at(10) = K(2, 2);
+    info.height = rgb.rows;
+    info.width = rgb.cols;
+    scene.waypoint = waypoint;
+    scene.episode_id = episode_id;
 }
 
 } // namespace quasimodo_conversions

--- a/quasimodo/quasimodo_conversions/src/quasimodo_conversions/conversions.cpp
+++ b/quasimodo/quasimodo_conversions/src/quasimodo_conversions/conversions.cpp
@@ -1,0 +1,136 @@
+#include <quasimodo_conversions/conversions.h>
+#include <soma_llsd/GetScene.h>
+#include <soma_llsd/InsertScene.h>
+
+namespace quasimodo_conversions {
+
+void model_to_soma_segment(ros::NodeHandle& n, const quasimodo_msgs::model& model, soma_llsd_msgs::Segment& segment)
+{
+    ros::ServiceClient client = n.serviceClient<soma_llsd::InsertScene>("/soma_llsd/insert_scene");
+    ROS_INFO("Waiting for /soma_llsd/insert_scene service...");
+    if (!client.waitForExistence(ros::Duration(1.0))) {
+        ROS_INFO("Failed to get /soma_llsd/insert_scene service!");
+        return;
+    }
+    ROS_INFO("Got /soma_llsd/insert_scene service");
+
+    segment.id = std::to_string(model.model_id);
+
+    size_t counter = 0;
+    for (const quasimodo_msgs::rgbd_frame& frame : model.frames) {
+        soma_llsd::InsertScene scene;
+        scene.request.rgb_img = frame.rgb;
+        scene.request.depth_img = frame.depth;
+        scene.request.camera_info = frame.camera;
+        scene.request.robot_pose = frame.pose; // not good actually but whatevs
+        scene.request.cloud = model.clouds[counter];
+
+        if (!client.call(scene)) {
+            ROS_ERROR("Failed to call service /soma_llsd/insert_scene");
+            return;
+        }
+
+        soma_llsd_msgs::Observation obs;
+        obs.scene_id = scene.response.response.id;
+        obs.camera_cloud = model.clouds[counter];
+        obs.image_mask = model.masks[counter];
+        //frame.camera = // see above
+        //frame.frame_id = // see
+        obs.pose = model.local_poses[counter]; //frame.pose;
+        //obs.pose = model.local_poses[counter];
+        obs.id = std::to_string(frame.frame_id);
+        obs.timestamp = ros::Time::now().nsec;
+        segment.observations.push_back(obs);
+        ++counter;
+    }
+
+}
+
+void soma_segment_to_model(ros::NodeHandle& n, const soma_llsd_msgs::Segment& segment, quasimodo_msgs::model& model)
+{
+    ros::ServiceClient client = n.serviceClient<soma_llsd::GetScene>("/soma_llsd/get_scene");
+    ROS_INFO("Waiting for /soma_llsd/get_scene service...");
+    if (!client.waitForExistence(ros::Duration(1.0))) {
+        ROS_INFO("Failed to get /soma_llsd/get_scene service!");
+        return;
+    }
+    ROS_INFO("Got /soma_llsd/get_scene service");
+
+    // segment.scene_id; // this can be used to fetch the scene from mongodb, from which we can get the camera parameters
+
+    model.model_id = std::stoi(segment.id);
+
+    for (const soma_llsd_msgs::Observation& obs : segment.observations) {
+        soma_llsd::GetScene srv;
+        srv.request.scene_id = obs.scene_id;
+        if (!client.call(srv)) {
+            ROS_ERROR("Failed to call service /soma_llsd/get_scene");
+            return;
+        }
+        model.clouds.push_back(obs.camera_cloud);
+        quasimodo_msgs::rgbd_frame frame;
+        frame.depth = srv.response.response.depth_img;
+        frame.rgb = srv.response.response.rgb_img;
+        model.masks.push_back(obs.image_mask);
+        //frame.camera = // see above
+        frame.frame_id = std::stoi(obs.id);
+        //frame.pose = obs.pose;
+        model.local_poses.push_back(obs.pose);
+        model.frames.push_back(frame);
+        model.local_poses.push_back(obs.pose);
+        //model.global_pose = // could probably get this from scene also?
+        //model.masks
+    }
+}
+
+void frame_to_soma_observation(ros::NodeHandle& n, const quasimodo_msgs::rgbd_frame& frame, soma_llsd_msgs::Observation& obs)
+{
+    ros::ServiceClient client = n.serviceClient<soma_llsd::InsertScene>("/soma_llsd/insert_scene");
+    ROS_INFO("Waiting for /soma_llsd/insert_scene service...");
+    if (!client.waitForExistence(ros::Duration(1.0))) {
+        ROS_INFO("Failed to get /soma_llsd/insert_scene service!");
+        return;
+    }
+    ROS_INFO("Got /soma_llsd/insert_scene service");
+
+    soma_llsd::InsertScene scene;
+    scene.request.rgb_img = frame.rgb;
+    scene.request.depth_img = frame.depth;
+    scene.request.camera_info = frame.camera;
+    scene.request.robot_pose = frame.pose; // not good actually but whatevs
+
+    if (!client.call(scene)) {
+        ROS_ERROR("Failed to call service /soma_llsd/insert_scene");
+        return;
+    }
+
+    obs.scene_id = scene.response.response.id;
+    obs.id = std::to_string(frame.frame_id);
+    obs.pose = frame.pose;
+}
+
+void soma_observation_to_frame(ros::NodeHandle& n, const soma_llsd_msgs::Observation& obs, quasimodo_msgs::rgbd_frame& frame)
+{
+    ros::ServiceClient client = n.serviceClient<soma_llsd::GetScene>("/soma_llsd/get_scene");
+    ROS_INFO("Waiting for /soma_llsd/get_scene service...");
+    if (!client.waitForExistence(ros::Duration(1.0))) {
+        ROS_INFO("Failed to get /soma_llsd/get_scene service!");
+        return;
+    }
+    ROS_INFO("Got /soma_llsd/get_scene service");
+
+    soma_llsd::GetScene srv;
+    srv.request.scene_id = obs.scene_id;
+    if (!client.call(srv)) {
+        ROS_ERROR("Failed to call service /soma_llsd/get_scene");
+        return;
+    }
+
+    frame.depth = srv.response.response.depth_img;
+    frame.rgb = srv.response.response.rgb_img;
+    //frame.camera = // see above
+    frame.frame_id = std::stoi(obs.id);
+    frame.pose = obs.pose; // not good actually but whatevs
+}
+
+} // namespace quasimodo_conversions

--- a/quasimodo/quasimodo_models/CMakeLists.txt
+++ b/quasimodo/quasimodo_models/CMakeLists.txt
@@ -95,6 +95,3 @@ install(TARGETS quasimodo_weightlib quasimodo_core quasimodo_reglib quasimodo_ma
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)

--- a/quasimodo/quasimodo_msgs/CMakeLists.txt
+++ b/quasimodo/quasimodo_msgs/CMakeLists.txt
@@ -51,12 +51,14 @@ add_message_files(
   retrieval_query.msg
   retrieval_query_result.msg
   SOMA2Object.msg
+  fused_world_state_object.msg
 )
 
 ## Generate services in the 'srv' folder
 add_service_files(
   FILES
   index_frame.srv
+  index_cloud.srv
   model_from_frame.srv
   cloud_from_model.srv
   fuse_models.srv
@@ -64,6 +66,7 @@ add_service_files(
   query_cloud.srv
   simple_query_cloud.srv
   visualize_query.srv
+  transform_cloud.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/quasimodo/quasimodo_msgs/CMakeLists.txt
+++ b/quasimodo/quasimodo_msgs/CMakeLists.txt
@@ -52,6 +52,8 @@ add_message_files(
   retrieval_query_result.msg
   SOMA2Object.msg
   fused_world_state_object.msg
+  model_array.msg
+  retrieval_query_array.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -69,6 +71,7 @@ add_service_files(
   transform_cloud.srv
   mask_pointclouds.srv
   insert_model.srv
+  model_to_retrieval_query.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/quasimodo/quasimodo_msgs/CMakeLists.txt
+++ b/quasimodo/quasimodo_msgs/CMakeLists.txt
@@ -68,6 +68,7 @@ add_service_files(
   visualize_query.srv
   transform_cloud.srv
   mask_pointclouds.srv
+  insert_model.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/quasimodo/quasimodo_msgs/CMakeLists.txt
+++ b/quasimodo/quasimodo_msgs/CMakeLists.txt
@@ -67,6 +67,7 @@ add_service_files(
   simple_query_cloud.srv
   visualize_query.srv
   transform_cloud.srv
+  mask_pointclouds.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
+++ b/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
@@ -9,3 +9,4 @@ sensor_msgs/Image[] masks
 geometry_msgs/Pose[] transforms
 string inserted_at
 string removed_at
+string associated_mongodb_fields_map

--- a/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
+++ b/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
@@ -3,3 +3,8 @@ sensor_msgs/PointCloud2 features
 sensor_msgs/PointCloud2 keypoints
 string object_id
 uint64 vocabulary_id
+sensor_msgs/Image[] images
+sensor_msgs/Image[] depths
+sensor_msgs/Image[] masks
+geometry_msgs/Pose[] transforms
+

--- a/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
+++ b/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
@@ -1,2 +1,5 @@
 sensor_msgs/PointCloud2 surfel_cloud
+sensor_msgs/PointCloud2 features
+sensor_msgs/PointCloud2 keypoints
 string object_id
+uint64 vocabulary_id

--- a/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
+++ b/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
@@ -1,0 +1,2 @@
+sensor_msgs/PointCloud2 surfel_cloud
+string object_id

--- a/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
+++ b/quasimodo/quasimodo_msgs/msg/fused_world_state_object.msg
@@ -7,4 +7,5 @@ sensor_msgs/Image[] images
 sensor_msgs/Image[] depths
 sensor_msgs/Image[] masks
 geometry_msgs/Pose[] transforms
-
+string inserted_at
+string removed_at

--- a/quasimodo/quasimodo_msgs/msg/model.msg
+++ b/quasimodo/quasimodo_msgs/msg/model.msg
@@ -3,4 +3,4 @@ geometry_msgs/Pose[] local_poses
 rgbd_frame[] frames
 sensor_msgs/Image[] masks
 sensor_msgs/PointCloud2[] clouds
-geometry_msgs/Pose[] global_pose
+geometry_msgs/Pose global_pose

--- a/quasimodo/quasimodo_msgs/msg/model.msg
+++ b/quasimodo/quasimodo_msgs/msg/model.msg
@@ -3,3 +3,4 @@ geometry_msgs/Pose[] local_poses
 rgbd_frame[] frames
 sensor_msgs/Image[] masks
 sensor_msgs/PointCloud2[] clouds
+geometry_msgs/Pose[] global_pose

--- a/quasimodo/quasimodo_msgs/msg/model.msg
+++ b/quasimodo/quasimodo_msgs/msg/model.msg
@@ -2,3 +2,4 @@ uint64 model_id
 geometry_msgs/Pose[] local_poses
 rgbd_frame[] frames
 sensor_msgs/Image[] masks
+sensor_msgs/PointCloud2[] clouds

--- a/quasimodo/quasimodo_msgs/msg/model_array.msg
+++ b/quasimodo/quasimodo_msgs/msg/model_array.msg
@@ -1,0 +1,1 @@
+quasimodo_msgs/model[] models

--- a/quasimodo/quasimodo_msgs/msg/retrieval_query.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_query.msg
@@ -5,6 +5,7 @@ sensor_msgs/PointCloud2 cloud
 sensor_msgs/Image image
 sensor_msgs/Image depth
 sensor_msgs/Image mask
+geometry_msgs/Pose global_pose
 sensor_msgs/CameraInfo camera
 int32 number_query
 geometry_msgs/Transform room_transform

--- a/quasimodo/quasimodo_msgs/msg/retrieval_query.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_query.msg
@@ -1,3 +1,6 @@
+uint64 ALL_QUERY = 0
+uint64 MONGODB_QUERY = 1
+uint64 METAROOM_QUERY = 2
 sensor_msgs/PointCloud2 cloud
 sensor_msgs/Image image
 sensor_msgs/Image depth
@@ -5,3 +8,4 @@ sensor_msgs/Image mask
 sensor_msgs/CameraInfo camera
 int32 number_query
 geometry_msgs/Transform room_transform
+uint64 query_kind

--- a/quasimodo/quasimodo_msgs/msg/retrieval_query_array.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_query_array.msg
@@ -1,0 +1,1 @@
+quasimodo_msgs/retrieval_query[] queries

--- a/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
@@ -7,4 +7,4 @@ string_array[] retrieved_image_paths
 float64[] retrieved_distance_scores
 int_array[] segment_indices
 geometry_msgs/Pose[] global_poses
-uint64[] vocabulary_ids
+string[] vocabulary_ids

--- a/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
@@ -6,3 +6,4 @@ image_array[] retrieved_masks
 string_array[] retrieved_image_paths
 float64[] retrieved_distance_scores
 int_array[] segment_indices
+geometry_msgs/Pose[] global_poses

--- a/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
+++ b/quasimodo/quasimodo_msgs/msg/retrieval_result.msg
@@ -7,3 +7,4 @@ string_array[] retrieved_image_paths
 float64[] retrieved_distance_scores
 int_array[] segment_indices
 geometry_msgs/Pose[] global_poses
+uint64[] vocabulary_ids

--- a/quasimodo/quasimodo_msgs/srv/index_cloud.srv
+++ b/quasimodo/quasimodo_msgs/srv/index_cloud.srv
@@ -1,0 +1,4 @@
+sensor_msgs/PointCloud2 cloud
+string object_id
+---
+uint64 id

--- a/quasimodo/quasimodo_msgs/srv/insert_model.srv
+++ b/quasimodo/quasimodo_msgs/srv/insert_model.srv
@@ -1,0 +1,8 @@
+uint64 INSERT=1
+uint64 REMOVE=2
+uint64 action
+quasimodo_msgs/model model
+uint64 object_id
+---
+uint64 vocabulary_id
+uint64 object_id

--- a/quasimodo/quasimodo_msgs/srv/insert_model.srv
+++ b/quasimodo/quasimodo_msgs/srv/insert_model.srv
@@ -2,7 +2,7 @@ uint64 INSERT=1
 uint64 REMOVE=2
 uint64 action
 quasimodo_msgs/model model
-uint64 object_id
+string object_id
 ---
 uint64 vocabulary_id
-uint64 object_id
+string object_id

--- a/quasimodo/quasimodo_msgs/srv/mask_pointclouds.srv
+++ b/quasimodo/quasimodo_msgs/srv/mask_pointclouds.srv
@@ -1,0 +1,4 @@
+sensor_msgs/PointCloud2[] clouds
+sensor_msgs/Image[] masks
+---
+sensor_msgs/PointCloud2[] clouds

--- a/quasimodo/quasimodo_msgs/srv/model_to_retrieval_query.srv
+++ b/quasimodo/quasimodo_msgs/srv/model_to_retrieval_query.srv
@@ -1,0 +1,3 @@
+quasimodo_msgs/model model
+---
+quasimodo_msgs/retrieval_query query

--- a/quasimodo/quasimodo_msgs/srv/transform_cloud.srv
+++ b/quasimodo/quasimodo_msgs/srv/transform_cloud.srv
@@ -1,0 +1,4 @@
+sensor_msgs/PointCloud2 cloud
+---
+sensor_msgs/PointCloud2 cloud1
+sensor_msgs/PointCloud2 cloud2

--- a/quasimodo/quasimodo_msgs/srv/visualize_query.srv
+++ b/quasimodo/quasimodo_msgs/srv/visualize_query.srv
@@ -2,3 +2,4 @@ retrieval_query query
 retrieval_result result
 ---
 sensor_msgs/Image image
+quasimodo_msgs/image_array images

--- a/quasimodo/quasimodo_object_search/CMakeLists.txt
+++ b/quasimodo/quasimodo_object_search/CMakeLists.txt
@@ -1,0 +1,181 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(quasimodo_object_search)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES quasimodo_object_search2
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+
+## Declare a C++ library
+# add_library(quasimodo_object_search2
+#   src/${PROJECT_NAME}/quasimodo_object_search2.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(quasimodo_object_search2 ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+# add_executable(quasimodo_object_search2_node src/quasimodo_object_search2_node.cpp)
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(quasimodo_object_search2_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(quasimodo_object_search2_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS quasimodo_object_search2 quasimodo_object_search2_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_quasimodo_object_search2.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/quasimodo/quasimodo_object_search/CMakeLists.txt
+++ b/quasimodo/quasimodo_object_search/CMakeLists.txt
@@ -146,6 +146,12 @@ catkin_package(
 #   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 # )
 
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+install(DIRECTORY scripts/
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        USE_SOURCE_PERMISSIONS)
+
 ## Mark executables and/or libraries for installation
 # install(TARGETS quasimodo_object_search2 quasimodo_object_search2_node
 #   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/quasimodo/quasimodo_object_search/launch/object_search.launch
+++ b/quasimodo/quasimodo_object_search/launch/object_search.launch
@@ -1,14 +1,16 @@
 <launch>
     <arg name="search_directly" default="false"/>
     <arg name="data_path" default="/home/strands/.semanticMap/vocabulary"/>
-    <arg name="enable_incremental" default="true"/>
+    <arg name="enable_incremental" default="false"/>
     <arg name="add_previous_maps" default="false"/>
     <arg name="start_add_map_ind" default="-1"/>
+    <arg name="min_match_depth" default="1"/>
 
     <include file="$(find quasimodo_retrieval)/launch/retrieval.launch">
         <arg name="search_directly" value="false"/>
         <arg name="vocabulary_path" value="$(arg data_path)/vocabulary"/>
         <arg name="enable_incremental" value="$(arg enable_incremental)"/>
+        <arg name="min_match_depth" value="$(arg min_match_depth)"/>
     </include>
 
     <include file="$(find retrieval_processing)/launch/processing.launch">

--- a/quasimodo/quasimodo_object_search/launch/object_search.launch
+++ b/quasimodo/quasimodo_object_search/launch/object_search.launch
@@ -2,7 +2,7 @@
     <arg name="search_directly" default="false"/>
     <arg name="data_path" default="/home/strands/.semanticMap/vocabulary"/>
     <arg name="enable_incremental" default="false"/>
-    <arg name="add_previous_maps" default="false"/>
+    <arg name="add_previous_maps" default="true"/>
     <arg name="start_add_map_ind" default="-1"/>
     <arg name="min_match_depth" default="1"/>
 

--- a/quasimodo/quasimodo_object_search/launch/object_search.launch
+++ b/quasimodo/quasimodo_object_search/launch/object_search.launch
@@ -1,0 +1,20 @@
+<launch>
+    <arg name="search_directly" default="false"/>
+    <arg name="data_path" default="/home/strands/.semanticMap/vocabulary"/>
+    <arg name="enable_incremental" default="false"/>
+
+    <include file="$(find quasimodo_retrieval)/launch/retrieval.launch">
+        <arg name="search_directly" value="false"/>
+        <arg name="vocabulary_path" value="$(arg data_path)/vocabulary"/>
+        <arg name="enable_incremental" value="$(arg enable_incremental)"/>
+    </include>
+
+    <include file="$(find retrieval_processing)/launch/processing.launch">
+        <arg name="data_path" value="$(arg data_path)"/>
+    </include>
+
+    <node pkg="quasimodo_object_search" type="insert_object_server.py" name="insert_object_server" output="screen" respawn="true"/>
+
+    <node pkg="surfelize_it" type="surfelize_server" name="surfelize_server" output="screen" respawn="true"/>
+
+</launch>

--- a/quasimodo/quasimodo_object_search/launch/object_search.launch
+++ b/quasimodo/quasimodo_object_search/launch/object_search.launch
@@ -1,7 +1,9 @@
 <launch>
     <arg name="search_directly" default="false"/>
     <arg name="data_path" default="/home/strands/.semanticMap/vocabulary"/>
-    <arg name="enable_incremental" default="false"/>
+    <arg name="enable_incremental" default="true"/>
+    <arg name="add_previous_maps" default="false"/>
+    <arg name="start_add_map_ind" default="-1"/>
 
     <include file="$(find quasimodo_retrieval)/launch/retrieval.launch">
         <arg name="search_directly" value="false"/>
@@ -11,6 +13,8 @@
 
     <include file="$(find retrieval_processing)/launch/processing.launch">
         <arg name="data_path" value="$(arg data_path)"/>
+        <arg name="add_previous_maps" value="$(arg add_previous_maps)"/>
+        <arg name="start_add_map_ind" value="$(arg start_add_map_ind)"/>
     </include>
 
     <node pkg="quasimodo_object_search" type="insert_object_server.py" name="insert_object_server" output="screen" respawn="true"/>

--- a/quasimodo/quasimodo_object_search/package.xml
+++ b/quasimodo/quasimodo_object_search/package.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<package>
+  <name>quasimodo_object_search</name>
+  <version>0.0.0</version>
+  <description>The quasimodo_object_search2 package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/quasimodo_object_search2</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -27,7 +27,7 @@ UPDATE_INT_MINUTES = 10.0
 def chron_callback():
 
     print("making query")
-    soma_query = rospy.ServiceProxy('soma/query_db',SOMAQueryObjs)
+    soma_query = rospy.ServiceProxy('soma/query_objects',SOMAQueryObjs)
     print("done query")
 
     # Query all observations during the last 30 mins

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -8,7 +8,7 @@ from cv_bridge import CvBridge, CvBridgeError
 import cv2
 
 # SOMA2 stuff
-from soma2_msgs.msg import SOMA2Object
+from soma_msgs.msg import SOMAObject
 from mongodb_store.message_store import MessageStoreProxy
 from soma_manager.srv import *
 from geometry_msgs.msg import Pose, Transform
@@ -27,11 +27,11 @@ UPDATE_INT_MINUTES = 10.0
 def chron_callback():
 
     print("making query")
-    soma_query = rospy.ServiceProxy('soma2/query_db',SOMA2QueryObjs)
+    soma_query = rospy.ServiceProxy('soma/query_db',SOMAQueryObjs)
     print("done query")
 
     # Query all observations during the last 30 mins
-    query = SOMA2QueryObjsRequest()
+    query = SOMAQueryObjsRequest()
     query.query_type = 0
     query.objecttypes=['unknown']
     query.uselowertime = True
@@ -166,7 +166,7 @@ def chron_callback():
 if __name__ == '__main__':
     rospy.init_node('create_object_search_observation', anonymous = False)
     print("getting soma service")
-    rospy.wait_for_service('soma2/query_db')
+    rospy.wait_for_service('soma/query_db')
     print("done initializing")
 
     r = rospy.Rate(1.0/(60.0*UPDATE_INT_MINUTES)) # 10hz

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+import roslib
+import rospy
+from sensor_msgs.msg import PointCloud2, PointField
+#from world_modeling.srv import *
+from cv_bridge import CvBridge, CvBridgeError
+import cv2
+
+# SOMA2 stuff
+from soma2_msgs.msg import SOMA2Object
+from mongodb_store.message_store import MessageStoreProxy
+from soma_manager.srv import *
+from geometry_msgs.msg import Pose, Transform
+from observation_registration_services.srv import ProcessRegisteredViews, ProcessRegisteredViewsRequest, ProcessRegisteredViewsResponse
+from soma_io.state import World, Object
+from datetime import datetime, timedelta
+from quasimodo_msgs.msg import fused_world_state_object
+from quasimodo_msgs.srv import transform_cloud, transform_cloudRequest, transform_cloudResponse
+from quasimodo_msgs.srv import index_cloud, index_cloudRequest, index_cloudResponse
+from quasimodo_msgs.srv import mask_pointclouds, mask_pointcloudsRequest, mask_pointcloudsResponse
+import time
+
+UPDATE_INT_MINUTES = 100000.0
+
+def chron_callback():
+
+    print("making query")
+    soma_query = rospy.ServiceProxy('soma2/query_db',SOMA2QueryObjs)
+    print("done query")
+
+    # Query all observations during the last 30 mins
+    query = SOMA2QueryObjsRequest()
+    query.query_type = 0
+    query.objecttypes=['unknown']
+    query.uselowertime = True
+    query.usedates = True
+    dt_obj = datetime.now() - timedelta(minutes=UPDATE_INT_MINUTES) #fromtimestamp(query.lowerdate
+    query.lowerhour = dt_obj.hour
+    print "Hour %d" % query.lowerhour
+    query.lowerminutes = dt_obj.minute
+    print "Minute %d" % query.lowerminutes
+
+    response = soma_query(query)
+
+    if not response.objects:
+        print("No SOMA objects!")
+    else:
+        print("got " + str(len(response.objects)) + " SOMA objects")
+        msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
+        world_model = World(server_host='localhost',server_port=62345)
+        #print world_model
+        for x in response.objects:
+            print(x.id)
+            wo = world_model.get_object(x.id)
+
+            transforms = [] #wo._poses
+            req = mask_pointcloudsRequest()
+            for obs, pose in zip(wo._observations, wo._poses):
+
+                #rgb = fo.get_message("/head_xtion/rgb/image_rect_color")
+                req.clouds.append(obs.get_message("/head_xtion/depth_registered/points"))
+                req.masks.append(obs.get_message("rgb_mask"))
+
+                #pointclouds.append(obs.get_message("object_cloud_camframe"))
+                #could we set everything that's in the background to inf/0?
+                transform = Transform()
+                transform.rotation.x = pose.quaternion.x
+                transform.rotation.y = pose.quaternion.y
+                transform.rotation.z = pose.quaternion.z
+                transform.rotation.w = pose.quaternion.w
+                transform.translation.x = pose.position.x
+                transform.translation.y = pose.position.y
+                transform.translation.z = pose.position.z
+
+                transforms.append(transform)
+
+            rospy.wait_for_service('retrieval_segmentation_server')
+            try:
+                surfelize_server = rospy.ServiceProxy('retrieval_segmentation_server', mask_pointclouds)
+                resp = surfelize_server(request)
+            except rospy.ServiceException, e:
+                print "Service call failed: %s"%e
+                return
+
+            #sensor_msgs/PointCloud2[] registered_views
+            #geometry_msgs/Transform[] registered_views_transforms
+            #std_msgs/Float32[]	  intrinsics # can be empty
+            #---
+            #sensor_msgs/PointCloud2 processed_cloud
+            request = ProcessRegisteredViewsRequest()
+            request.registered_views = resp.clouds
+            # This should possibly be transformed to the frame of the first
+            # observation to make visualization a bit easier
+            request.registered_views_transforms = transforms
+
+            rospy.wait_for_service('surfelize_server')
+            try:
+                surfelize_server = rospy.ServiceProxy('surfelize_server', ProcessRegisteredViews)
+                resp = surfelize_server(request)
+            except rospy.ServiceException, e:
+                print "Service call failed: %s"%e
+                return
+
+            new_obj = fused_world_state_object()
+            new_obj.surfel_cloud = resp.processed_cloud
+            new_obj.object_id = x.id
+
+            rospy.wait_for_service('retrieval_features_service')
+            req = transform_cloudRequest()
+            req.cloud = new_obj.surfel_cloud
+            try:
+                surfelize_server = rospy.ServiceProxy('retrieval_features_service', transform_cloud)
+                resp = surfelize_server(request)
+            except rospy.ServiceException, e:
+                print "Service call failed: %s"%e
+                return
+
+            new_obj.features = resp.cloud1
+            new_obj.keypoints = resp.cloud2
+
+            object_id = msg_store.insert(new_obj)
+
+            rospy.wait_for_service('retrieval_vocabulary_service')
+            req = index_cloudRequest()
+            req.cloud = new_obj.surfel_cloud
+            req.object_id = object_id
+            try:
+                surfelize_server = rospy.ServiceProxy('retrieval_vocabulary_service', index_cloud)
+                resp = surfelize_server(request)
+            except rospy.ServiceException, e:
+                print "Service call failed: %s"%e
+                return
+
+            new_obj.vocabulary_index = resp.id
+            msg_store.update_id(object_id, new_obj)
+            # Now, simply save this in mongodb, or maybe extract features first?
+
+            print object_id
+
+            break
+
+
+
+    print("done")
+
+
+if __name__ == '__main__':
+    rospy.init_node('create_object_search_observation', anonymous = False)
+    print("getting soma service")
+    rospy.wait_for_service('soma2/query_db')
+    print("done initializing")
+
+    r = rospy.Rate(1.0/(60.0*UPDATE_INT_MINUTES)) # 10hz
+    while not rospy.is_shutdown():
+        chron_callback()
+        r.sleep()

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -109,6 +109,8 @@ def chron_callback():
             new_obj = fused_world_state_object()
             new_obj.surfel_cloud = resp.processed_cloud
             new_obj.object_id = x.id
+            now = datetime.now()
+            new_obj.inserted_at = now.strftime("%Y-%m-%d %H:%M:%S")
 
             for obs, pose in zip(wo._observations, wo._poses):
                 new_obj.transforms.append(Pose())

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -22,7 +22,7 @@ from quasimodo_msgs.srv import mask_pointclouds, mask_pointcloudsRequest, mask_p
 from geometry_msgs.msg import Pose
 import time
 
-UPDATE_INT_MINUTES = 100000.0
+UPDATE_INT_MINUTES = 10.0
 
 def chron_callback():
 
@@ -156,7 +156,7 @@ def chron_callback():
 
             print object_id
 
-            break
+            #break # if you only want to add one object
 
 
 

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -19,6 +19,7 @@ from quasimodo_msgs.msg import fused_world_state_object
 from quasimodo_msgs.srv import transform_cloud, transform_cloudRequest, transform_cloudResponse
 from quasimodo_msgs.srv import index_cloud, index_cloudRequest, index_cloudResponse
 from quasimodo_msgs.srv import mask_pointclouds, mask_pointcloudsRequest, mask_pointcloudsResponse
+from geometry_msgs.msg import Pose
 import time
 
 UPDATE_INT_MINUTES = 100000.0
@@ -107,6 +108,16 @@ def chron_callback():
             new_obj = fused_world_state_object()
             new_obj.surfel_cloud = resp.processed_cloud
             new_obj.object_id = x.id
+
+            for obs, pose in zip(wo._observations, wo._poses):
+                new_obj.transforms.append(Pose())
+                new_obj.transforms[-1].position.x = pose.position.x
+                new_obj.transforms[-1].position.y = pose.position.y
+                new_obj.transforms[-1].position.z = pose.position.z
+                new_obj.transforms[-1].orientation.x = pose.quaternion.x
+                new_obj.transforms[-1].orientation.y = pose.quaternion.y
+                new_obj.transforms[-1].orientation.z = pose.quaternion.z
+                new_obj.transforms[-1].orientation.w = pose.quaternion.w
 
             print "Waiting for retrieval_features_service..."
             rospy.wait_for_service('retrieval_features_service')

--- a/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
+++ b/quasimodo/quasimodo_object_search/scripts/create_object_search_observation.py
@@ -49,6 +49,7 @@ def chron_callback():
     else:
         print("got " + str(len(response.objects)) + " SOMA objects")
         msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
+        # This hardcoding is no good!
         world_model = World(server_host='localhost',server_port=62345)
         #print world_model
         for x in response.objects:

--- a/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
+++ b/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
@@ -8,7 +8,7 @@ from cv_bridge import CvBridge, CvBridgeError
 import cv2
 
 # SOMA2 stuff
-from soma2_msgs.msg import SOMA2Object
+from soma_msgs.msg import SOMAObject
 from mongodb_store.message_store import MessageStoreProxy
 from soma_manager.srv import *
 from geometry_msgs.msg import Pose, Transform

--- a/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
+++ b/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
@@ -23,14 +23,14 @@ from quasimodo_msgs.srv import insert_model, insert_modelRequest, insert_modelRe
 from geometry_msgs.msg import Pose
 import time
 
-def insert_model_cb():
+def insert_model_cb(req):
     msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
 
     transforms = []
-    req = mask_pointcloudsRequest()
+    mreq = mask_pointcloudsRequest()
     for cloud, mask, pose in zip(req.model.clouds, req.model.masks, req.model.local_poses):
-        req.clouds.append(cloud)
-        req.masks.append(mask)
+        mreq.clouds.append(cloud)
+        mreq.masks.append(mask)
 
         transform = Transform()
         transform.rotation.x = pose.quaternion.x
@@ -46,7 +46,7 @@ def insert_model_cb():
     rospy.wait_for_service('retrieval_segmentation_service')
     try:
         surfelize_server = rospy.ServiceProxy('retrieval_segmentation_service', mask_pointclouds)
-        resp = surfelize_server(req)
+        resp = surfelize_server(mreq)
     except rospy.ServiceException, e:
         print "Service call failed: %s"%e
         return False
@@ -66,7 +66,7 @@ def insert_model_cb():
 
     new_obj = fused_world_state_object()
     new_obj.surfel_cloud = resp.processed_cloud
-    new_obj.object_id = x.id
+    new_obj.object_id = resp.id
     now = datetime.now()
     new_obj.inserted_at = now.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
+++ b/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+
+import roslib
+import rospy
+from sensor_msgs.msg import PointCloud2, PointField
+#from world_modeling.srv import *
+from cv_bridge import CvBridge, CvBridgeError
+import cv2
+
+# SOMA2 stuff
+from soma2_msgs.msg import SOMA2Object
+from mongodb_store.message_store import MessageStoreProxy
+from soma_manager.srv import *
+from geometry_msgs.msg import Pose, Transform
+from observation_registration_services.srv import ProcessRegisteredViews, ProcessRegisteredViewsRequest, ProcessRegisteredViewsResponse
+from soma_io.state import World, Object
+from datetime import datetime, timedelta
+from quasimodo_msgs.msg import fused_world_state_object
+from quasimodo_msgs.srv import transform_cloud, transform_cloudRequest, transform_cloudResponse
+from quasimodo_msgs.srv import index_cloud, index_cloudRequest, index_cloudResponse
+from quasimodo_msgs.srv import mask_pointclouds, mask_pointcloudsRequest, mask_pointcloudsResponse
+from quasimodo_msgs.srv import insert_model, insert_modelRequest, insert_modelResponse
+from geometry_msgs.msg import Pose
+import time
+
+def insert_model():
+    msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
+
+    transforms = []
+    req = mask_pointcloudsRequest()
+    for cloud, mask, pose in zip(req.model.clouds, req.model.masks, req.model.local_poses):
+        req.clouds.append(cloud)
+        req.masks.append(mask)
+
+        transform = Transform()
+        transform.rotation.x = pose.quaternion.x
+        transform.rotation.y = pose.quaternion.y
+        transform.rotation.z = pose.quaternion.z
+        transform.rotation.w = pose.quaternion.w
+        transform.translation.x = pose.position.x
+        transform.translation.y = pose.position.y
+        transform.translation.z = pose.position.z
+        transforms.append(transform)
+
+    print "Waiting for retrieval_segmentation_service..."
+    rospy.wait_for_service('retrieval_segmentation_service')
+    try:
+        surfelize_server = rospy.ServiceProxy('retrieval_segmentation_service', mask_pointclouds)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return False
+
+    req = ProcessRegisteredViewsRequest()
+    req.registered_views = resp.clouds
+    req.registered_views_transforms = transforms
+
+    print "Waiting for surfelize_server..."
+    rospy.wait_for_service('surfelize_server')
+    try:
+        surfelize_server = rospy.ServiceProxy('surfelize_server', ProcessRegisteredViews)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return False
+
+    new_obj = fused_world_state_object()
+    new_obj.surfel_cloud = resp.processed_cloud
+    new_obj.object_id = x.id
+    now = datetime.now()
+    new_obj.inserted_at = now.strftime("%Y-%m-%d %H:%M:%S")
+
+    for obs, pose in zip(wo._observations, wo._poses):
+        new_obj.transforms.append(Pose())
+        new_obj.transforms[-1].position.x = pose.position.x
+        new_obj.transforms[-1].position.y = pose.position.y
+        new_obj.transforms[-1].position.z = pose.position.z
+        new_obj.transforms[-1].orientation.x = pose.quaternion.x
+        new_obj.transforms[-1].orientation.y = pose.quaternion.y
+        new_obj.transforms[-1].orientation.z = pose.quaternion.z
+        new_obj.transforms[-1].orientation.w = pose.quaternion.w
+
+    print "Waiting for retrieval_features_service..."
+    rospy.wait_for_service('retrieval_features_service')
+    req = transform_cloudRequest()
+    req.cloud = resp.processed_cloud
+    try:
+        surfelize_server = rospy.ServiceProxy('retrieval_features_service', transform_cloud)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return False
+
+    new_obj.features = resp.cloud1
+    new_obj.keypoints = resp.cloud2
+
+    object_id = msg_store.insert(new_obj)
+
+    print "Waiting for retrieval_vocabulary_service..."
+    rospy.wait_for_service('retrieval_vocabulary_service')
+    req = index_cloudRequest()
+    req.cloud = new_obj.features
+    req.object_id = object_id
+    try:
+        surfelize_server = rospy.ServiceProxy('retrieval_vocabulary_service', index_cloud)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return False
+
+    new_obj.vocabulary_id = resp.id
+    msg_store.update_id(object_id, new_obj)
+    # Now, simply save this in mongodb, or maybe extract features first?
+
+    print object_id
+
+    print("done")
+
+    resp = insert_modelResponse()
+    resp.vocabulary_id = new_obj.vocabulary_id
+    resp.object_id = new_obj.object_id
+
+    return resp
+
+def remove_model(req):
+
+    msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
+    # msg_store.delete(req.object_id)
+    # resp = insert_modelResponse()
+    # resp.object_id = req.object_id
+
+    new_obj = msg_store.query_id(req.object_id, fused_world_state_object)
+    now = datetime.now()
+    new_obj.removed_at = now.strftime("%Y-%m-%d %H:%M:%S")
+    msg_store.update_id(req.object_id, new_obj)
+
+    return resp
+
+def service_callback(req):
+
+    if req.action == insert_modelRequest.REMOVE:
+        resp = remove_model(req)
+        if not resp:
+            print "Failed to remove model..."
+    elif req.action == insert_modelRequest.INSERT:
+        resp = insert_model(req)
+        if not resp:
+            print "Failed to remove model..."
+    else:
+        resp = False
+        print "Service options are 1: INSERT and 2: REMOVE"
+
+    return resp
+
+if __name__ == '__main__':
+    rospy.init_node('insert_object_server', anonymous = False)
+
+    service = rospy.Service('insert_model_service', insert_model, service_callback)
+
+    rospy.spin()

--- a/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
+++ b/quasimodo/quasimodo_object_search/scripts/insert_object_server.py
@@ -23,7 +23,7 @@ from quasimodo_msgs.srv import insert_model, insert_modelRequest, insert_modelRe
 from geometry_msgs.msg import Pose
 import time
 
-def insert_model():
+def insert_model_cb():
     msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
 
     transforms = []
@@ -118,32 +118,37 @@ def insert_model():
 
     resp = insert_modelResponse()
     resp.vocabulary_id = new_obj.vocabulary_id
-    resp.object_id = new_obj.object_id
+    resp.object_id = object_id
 
     return resp
 
-def remove_model(req):
+def remove_model_cb(req):
 
     msg_store = MessageStoreProxy(database='world_state', collection='quasimodo')
     # msg_store.delete(req.object_id)
     # resp = insert_modelResponse()
     # resp.object_id = req.object_id
 
-    new_obj = msg_store.query_id(req.object_id, fused_world_state_object)
+    new_obj = msg_store.query_id(req.object_id, 'quasimodo_msgs/fused_world_state_object')[0]
+    #print new_obj
     now = datetime.now()
     new_obj.removed_at = now.strftime("%Y-%m-%d %H:%M:%S")
     msg_store.update_id(req.object_id, new_obj)
+
+    resp = insert_modelResponse()
+    resp.vocabulary_id = new_obj.vocabulary_id
+    resp.object_id = req.object_id
 
     return resp
 
 def service_callback(req):
 
     if req.action == insert_modelRequest.REMOVE:
-        resp = remove_model(req)
+        resp = remove_model_cb(req)
         if not resp:
             print "Failed to remove model..."
     elif req.action == insert_modelRequest.INSERT:
-        resp = insert_model(req)
+        resp = insert_model_cb(req)
         if not resp:
             print "Failed to remove model..."
     else:

--- a/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
+++ b/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
@@ -9,7 +9,7 @@ import cv2
 import numpy as np
 
 # SOMA2 stuff
-from soma2_msgs.msg import SOMA2Object
+from soma_msgs.msg import SOMAObject
 from mongodb_store.message_store import MessageStoreProxy
 from soma_manager.srv import *
 from geometry_msgs.msg import Pose, Transform

--- a/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
+++ b/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
@@ -95,6 +95,8 @@ def retrieval_callback(object_id):
     query.mask = CvBridge().cv2_to_imgmsg(cv_mask, "mono8") #masks[0]
     query.number_query = 10
     query.room_transform = transforms[0]
+    #query.query_kind = retrieval_query.ALL_QUERY
+    query.query_kind = retrieval_query.MONGODB_QUERY
 
     pub.publish(query)
     resp.processed_cloud.header.frame_id = "/map"

--- a/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
+++ b/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
@@ -29,6 +29,7 @@ pub = ()
 
 def retrieval_callback(object_id):
 
+    # This hardcoding is no good!
     world_model = World(server_host='localhost',server_port=62345)
     print(object_id)
     wo = world_model.get_object(object_id)
@@ -99,4 +100,5 @@ def retrieval_callback(object_id):
 if __name__ == '__main__':
     rospy.init_node('retrieve_object_search', anonymous = False)
     pub = rospy.Publisher("/models/query", retrieval_query)
+    sub = rospy.Subscriber("/models/mongodb_query", std_msgs.String, callback=retrieval_callback)
     rospy.spin()

--- a/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
+++ b/quasimodo/quasimodo_object_search/scripts/retrieve_object_search.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import roslib
+import rospy
+from sensor_msgs.msg import PointCloud2, PointField
+#from world_modeling.srv import *
+from cv_bridge import CvBridge, CvBridgeError
+import cv2
+
+# SOMA2 stuff
+from soma2_msgs.msg import SOMA2Object
+from mongodb_store.message_store import MessageStoreProxy
+from soma_manager.srv import *
+from geometry_msgs.msg import Pose, Transform
+from observation_registration_services.srv import ProcessRegisteredViews, ProcessRegisteredViewsRequest, ProcessRegisteredViewsResponse
+from soma_io.state import World, Object
+from datetime import datetime, timedelta
+from quasimodo_msgs.msg import fused_world_state_object
+from quasimodo_msgs.srv import transform_cloud, transform_cloudRequest, transform_cloudResponse
+from quasimodo_msgs.srv import index_cloud, index_cloudRequest, index_cloudResponse
+from quasimodo_msgs.srv import mask_pointclouds, mask_pointcloudsRequest, mask_pointcloudsResponse
+from quasimodo_msgs.msg import retrieval_query
+from geometry_msgs.msg import Pose
+import time
+
+UPDATE_INT_MINUTES = 100000.0
+
+pub = ()
+
+def retrieval_callback(object_id):
+
+    world_model = World(server_host='localhost',server_port=62345)
+    print(object_id)
+    wo = world_model.get_object(object_id)
+
+    transforms = [] #wo._poses
+    images = []
+    depths = []
+    masks = []
+    cameras = []
+    req = mask_pointcloudsRequest()
+    for obs, pose in zip(wo._observations, wo._poses):
+
+        images.append(fo.get_message("/head_xtion/rgb/image_rect_color"))
+        depthmat = np.zeros((480,640,1), np.uint16)
+        # have to be careful here, Johan has a different encoding
+        depths.append(CvBridge().cv2_to_imgmsg(depthmat, "mono16"))
+        masks.append(fo.get_message("rgb_mask"))
+        cameras = fo.get_message("/head_xtion/depth_registered/sw_registered/camera_info")
+        req.clouds.append(obs.get_message("/head_xtion/depth_registered/points"))
+        req.masks.append(obs.get_message("rgb_mask"))
+
+        transform = Transform()
+        transform.rotation.x = pose.quaternion.x
+        transform.rotation.y = pose.quaternion.y
+        transform.rotation.z = pose.quaternion.z
+        transform.rotation.w = pose.quaternion.w
+        transform.translation.x = pose.position.x
+        transform.translation.y = pose.position.y
+        transform.translation.z = pose.position.z
+
+        transforms.append(transform)
+
+    print "Waiting for retrieval_segmentation_service..."
+    rospy.wait_for_service('retrieval_segmentation_service')
+    try:
+        surfelize_server = rospy.ServiceProxy('retrieval_segmentation_service', mask_pointclouds)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return
+
+    req = ProcessRegisteredViewsRequest()
+    req.registered_views = resp.clouds
+    req.registered_views_transforms = transforms
+
+    print "Waiting for surfelize_server..."
+    rospy.wait_for_service('surfelize_server')
+    try:
+        surfelize_server = rospy.ServiceProxy('surfelize_server', ProcessRegisteredViews)
+        resp = surfelize_server(req)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+        return
+
+    query = retrieval_query()
+    query.camera = cameras[0]
+    query.cloud = resp.processed_cloud
+    query.depth = depths[0]
+    query.image = images[0]
+    query.mask = masks[0]
+    query.number_query = 10
+    query.room_transform = transforms[0]
+
+    pub.publish(query)
+
+    print("done")
+
+if __name__ == '__main__':
+    rospy.init_node('retrieve_object_search', anonymous = False)
+    pub = rospy.Publisher("/models/query", retrieval_query)
+    rospy.spin()

--- a/quasimodo/quasimodo_retrieval/CMakeLists.txt
+++ b/quasimodo/quasimodo_retrieval/CMakeLists.txt
@@ -175,6 +175,7 @@ add_executable(quasimodo_retrieval_server src/quasimodo_retrieval_server.cpp)
 add_executable(quasimodo_retrieval_publisher src/quasimodo_retrieval_publisher.cpp)
 add_executable(quasimodo_visualization_server src/quasimodo_visualization_server.cpp)
 add_executable(quasimodo_visualize_model src/quasimodo_visualize_model.cpp)
+add_executable(quasimodo_visualize_retrieval_cloud src/quasimodo_visualize_retrieval_cloud.cpp)
 add_executable(quasimodo_retrieval_node src/quasimodo_retrieval_node.cpp)
 add_executable(quasimodo_retrieve_observation src/quasimodo_retrieve_observation.cpp)
 add_executable(quasimodo_logging_server src/quasimodo_logging_server.cpp)
@@ -216,6 +217,13 @@ target_link_libraries(quasimodo_retrieval_publisher
 target_link_libraries(quasimodo_visualize_model
 #  ${retrieval_libraries}
 #  ${benchmark_libraries}
+  ${OpenCV_LIBS}
+  ${QT_QTMAIN_LIBRARY} ${QT_LIBRARIES}
+  ${PCL_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(quasimodo_visualize_retrieval_cloud
   ${OpenCV_LIBS}
   ${QT_QTMAIN_LIBRARY} ${QT_LIBRARIES}
   ${PCL_LIBRARIES}
@@ -281,7 +289,7 @@ install(
 
 # Mark executables and/or libraries for installation
 install(TARGETS quasimodo_retrieval_server quasimodo_retrieval_publisher quasimodo_visualization_server
-                quasimodo_visualize_model quasimodo_retrieval_node quasimodo_retrieve_observation quasimodo_logging_server
+                quasimodo_visualize_model quasimodo_visualize_retrieval_cloud quasimodo_retrieval_node quasimodo_retrieve_observation quasimodo_logging_server
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/quasimodo/quasimodo_retrieval/CMakeLists.txt
+++ b/quasimodo/quasimodo_retrieval/CMakeLists.txt
@@ -8,7 +8,7 @@ add_definitions(-std=c++11 -O3)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp tf sensor_msgs std_msgs image_geometry metaroom_xml_parser quasimodo_msgs message_runtime
                                         message_generation tf_conversions pcl_ros image_geometry cv_bridge tf_conversions eigen_conversions
-                                        k_means_tree dynamic_object_retrieval object_3d_benchmark dynamic_reconfigure soma2_msgs)
+                                        k_means_tree dynamic_object_retrieval object_3d_benchmark dynamic_reconfigure soma_msgs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -186,7 +186,7 @@ add_dependencies(quasimodo_visualization_server quasimodo_msgs_generate_messages
 add_dependencies(quasimodo_visualize_model quasimodo_msgs_generate_messages_cpp)
 add_dependencies(quasimodo_retrieval_node quasimodo_msgs_generate_messages_cpp)
 add_dependencies(quasimodo_retrieve_observation quasimodo_msgs_generate_messages_cpp)
-add_dependencies(quasimodo_logging_server quasimodo_msgs_generate_messages_cpp soma2_msgs_generate_messages_cpp)
+add_dependencies(quasimodo_logging_server quasimodo_msgs_generate_messages_cpp soma_msgs_generate_messages_cpp)
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above

--- a/quasimodo/quasimodo_retrieval/launch/retrieval.launch
+++ b/quasimodo/quasimodo_retrieval/launch/retrieval.launch
@@ -2,11 +2,13 @@
     <arg name="search_directly" default="false"/>
     <arg name="vocabulary_path" default="/home/strands/.semanticMap/vocabulary"/>
     <arg name="enable_incremental" default="false"/>
+    <arg name="min_match_depth" default="3"/>
 
     <node pkg="surfelize_it" type="topic_processor" name="topic_processor" output="screen" respawn="true"/>
     <node pkg="quasimodo_retrieval" type="quasimodo_retrieval_node" name="quasimodo_retrieval_node" output="screen" respawn="true">
         <param name="vocabulary_path" value="$(arg vocabulary_path)"/>
         <param name="enable_incremental" value="$(arg enable_incremental)"/>
+        <param name="min_match_depth" value="$(arg min_match_depth)"/>
     </node>
     <node pkg="quasimodo_retrieval" type="quasimodo_visualization_server" name="quasimodo_visualization_server" output="screen" respawn="true"/>
     <node pkg="quasimodo_retrieval" type="quasimodo_logging_server" name="quasimodo_logging_server" output="screen" respawn="true"/>

--- a/quasimodo/quasimodo_retrieval/launch/retrieval.launch
+++ b/quasimodo/quasimodo_retrieval/launch/retrieval.launch
@@ -1,10 +1,12 @@
 <launch>
     <arg name="search_directly" default="false"/>
     <arg name="vocabulary_path" default="/home/strands/.semanticMap/vocabulary"/>
+    <arg name="enable_incremental" default="true"/>
 
     <node pkg="surfelize_it" type="topic_processor" name="topic_processor" output="screen" respawn="true"/>
     <node pkg="quasimodo_retrieval" type="quasimodo_retrieval_node" name="quasimodo_retrieval_node" output="screen" respawn="true">
         <param name="vocabulary_path" value="$(arg vocabulary_path)"/>
+        <param name="enable_incremental" value="$(arg enable_incremental)"/>
     </node>
     <node pkg="quasimodo_retrieval" type="quasimodo_visualization_server" name="quasimodo_visualization_server" output="screen" respawn="true"/>
     <node pkg="quasimodo_retrieval" type="quasimodo_logging_server" name="quasimodo_logging_server" output="screen" respawn="true"/>

--- a/quasimodo/quasimodo_retrieval/launch/retrieval.launch
+++ b/quasimodo/quasimodo_retrieval/launch/retrieval.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="search_directly" default="false"/>
     <arg name="vocabulary_path" default="/home/strands/.semanticMap/vocabulary"/>
-    <arg name="enable_incremental" default="true"/>
+    <arg name="enable_incremental" default="false"/>
 
     <node pkg="surfelize_it" type="topic_processor" name="topic_processor" output="screen" respawn="true"/>
     <node pkg="quasimodo_retrieval" type="quasimodo_retrieval_node" name="quasimodo_retrieval_node" output="screen" respawn="true">

--- a/quasimodo/quasimodo_retrieval/package.xml
+++ b/quasimodo/quasimodo_retrieval/package.xml
@@ -58,7 +58,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>libqt4-dev</build_depend>
   <build_depend>libqt4-opengl-dev</build_depend>
-  <build_depend>soma2_msgs</build_depend>
+  <build_depend>soma_msgs</build_depend>
   <run_depend>libpcl-all</run_depend>
   <run_depend>libopencv-dev</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -77,7 +77,7 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>libqt4</run_depend>
   <run_depend>libqt4-opengl</run_depend>
-  <run_depend>soma2_msgs</run_depend>
+  <run_depend>soma_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -55,7 +55,14 @@ def create_analysis_for_type(type):
 
     nbr_queries = len(queries)
 
-    return rooms, nbr_queries, nbr_results
+    reversed_dict = {}
+    for k, v in rooms.items():
+        if v in reversed_dict:
+            v += 1
+        else:
+            v = 1
+
+    return rooms, reversed_dict, nbr_results
 
 def get_metaroom_segment_stats(data_path):
 
@@ -79,9 +86,9 @@ def run(data_path):
     t.add_row(['Indexed sweeps:', '-', nbr_sweeps])
     t.add_row(['Indexed segments:', '-', nbr_segments])
     for k, v in db_rooms.items():
-        t.add_row([k, v, '-'])
+        t.add_row(["Sweeps with %d nbr search results: " % k, v, '-'])
     for k, v in metaroom_rooms.items():
-        t.add_row([k, '-', v])
+        t.add_row(["Sweeps with %d nbr search results: " % k, v, '-'])
 
     print t
 

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -33,7 +33,7 @@ def create_analysis_for_type(type):
 
     if not response.objects:
         print("No SOMA objects!")
-        return [], 0, 0
+        return {}, 0, 0
 
     response.objects = [x for x in response.objects if x.type == type] # for some reason the objecttype doesn't get filtered?
 

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+from soma_msgs.msg import SOMAObject
+from mongodb_store.message_store import MessageStoreProxy
+from soma_manager.srv import *
+#from tabulate import tabulate
+from prettytable import PrettyTable
+
+def create_analysis_for_type(type):
+    print("making query")
+    soma_query = rospy.ServiceProxy('soma/query_db', SOMAQueryObjs)
+    print("done query")
+
+    # Query all observations during the last 30 mins
+    query = SOMAQueryObjsRequest()
+    query.query_type = 0
+    query.objecttypes=[type]
+    query.configs = ['quasimodo_retrieval_result']
+
+    #query.uselowertime = True
+    #query.usedates = True
+    #dt_obj = datetime.now() - timedelta(minutes=UPDATE_INT_MINUTES) #fromtimestamp(query.lowerdate
+    #query.lowerhour = dt_obj.hour
+    #print "Hour %d" % query.lowerhour
+    #query.lowerminutes = dt_obj.minute
+    #print "Minute %d" % query.lowerminutes
+
+    response = soma_query(query)
+
+    if not response.objects:
+        print("No SOMA objects!")
+        return
+
+    rooms = {}
+    queries = {}
+    nbr_results = len(response.objects)
+
+    for x in response.objects:
+        ids = x.id.split()
+
+        if x.metadata in queries:
+            queries[x.metadata] += 1
+        else
+            queries[x.metadata] = 1
+
+        if ids[0] in rooms:
+            rooms[ids[0]] += 1
+        else
+            rooms[ids[0]] = 1
+
+    nbr_queries = len(queries)
+
+    return rooms, nbr_queries, nbr_results
+
+if __name__ == '__main__':
+    db_rooms, db_nbr_queries, db_nbr_results = create_analysis_for_type("quasimodo_db_result")
+    metaroom_rooms, metaroom_nbr_queries, metaroom_nbr_results = create_analysis_for_type("quasimodo_metaroom_result")
+
+    t = PrettyTable(['Entity', 'Quasimodo Model DB Query', 'Quasimodo Metarooms Query'])
+    t.add_row(['Number queries:', db_nbr_queries, metaroom_nbr_queries])
+    t.add_row(['Number results:', db_nbr_results, metaroom_nbr_results])
+    for k, v in db_rooms.items()
+        t.add_row([k, v, 0])
+    for k, v in metaroom_rooms.items()
+        t.add_row([k, 0, v])
+
+    print t

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -8,6 +8,7 @@ from soma_manager.srv import *
 from prettytable import PrettyTable
 import json
 import os.path
+from quasimodo_msgs.msg import fused_world_state_object
 
 def create_analysis_for_type(type):
     print("making query")
@@ -74,8 +75,14 @@ def get_metaroom_segment_stats(data_path):
 
     return nbr_sweeps, nbr_segments
 
+def get_database_segment_stats():
+    msg_store = MessageStoreProxy(database="world_state", collection="quasimodo")
+    resp = msg_store.query(fused_world_state_object._type, message_query={"removed_at": ""})
+    print resp
+
 def run(data_path):
 
+    get_database_segment_stats()
     nbr_sweeps, nbr_segments = get_metaroom_segment_stats(data_path)
     db_rooms, db_nbr_queries, db_nbr_results = create_analysis_for_type("quasimodo_db_result")
     metaroom_rooms, metaroom_nbr_queries, metaroom_nbr_results = create_analysis_for_type("quasimodo_metaroom_result")
@@ -86,7 +93,7 @@ def run(data_path):
     t.add_row(['Indexed sweeps:', '-', nbr_sweeps])
     t.add_row(['Indexed segments:', '-', nbr_segments])
     for k, v in db_rooms.items():
-        t.add_row(["Sweeps with %d nbr search results: " % k, v, '-'])
+        t.add_row(["Objects with %d nbr search results: " % k, v, '-'])
     for k, v in metaroom_rooms.items():
         t.add_row(["Sweeps with %d nbr search results: " % k, v, '-'])
 

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -32,6 +32,8 @@ def create_analysis_for_type(type):
         print("No SOMA objects!")
         return
 
+    response.objects = [x for x in response.objects if x.type == type] # for some reason the objecttype doesn't get filtered?
+
     rooms = {}
     queries = {}
     nbr_results = len(response.objects)

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -30,7 +30,7 @@ def create_analysis_for_type(type):
 
     if not response.objects:
         print("No SOMA objects!")
-        return
+        return [], 0, 0
 
     response.objects = [x for x in response.objects if x.type == type] # for some reason the objecttype doesn't get filtered?
 

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -78,11 +78,11 @@ def get_metaroom_segment_stats(data_path):
 def get_database_segment_stats():
     msg_store = MessageStoreProxy(database="world_state", collection="quasimodo")
     resp = msg_store.query(fused_world_state_object._type, message_query={"removed_at": ""})
-    print resp
+    return len(resp)
 
 def run(data_path):
 
-    get_database_segment_stats()
+    nbr_objects = get_database_segment_stats()
     nbr_sweeps, nbr_segments = get_metaroom_segment_stats(data_path)
     db_rooms, db_nbr_queries, db_nbr_results = create_analysis_for_type("quasimodo_db_result")
     metaroom_rooms, metaroom_nbr_queries, metaroom_nbr_results = create_analysis_for_type("quasimodo_metaroom_result")
@@ -91,7 +91,7 @@ def run(data_path):
     t.add_row(['Number queries:', db_nbr_queries, metaroom_nbr_queries])
     t.add_row(['Number results:', db_nbr_results, metaroom_nbr_results])
     t.add_row(['Indexed sweeps:', '-', nbr_sweeps])
-    t.add_row(['Indexed segments:', '-', nbr_segments])
+    t.add_row(['Indexed segments:', nbr_objects, nbr_segments])
     for k, v in db_rooms.items():
         t.add_row(["Objects with %d nbr search results: " % k, v, '-'])
     for k, v in metaroom_rooms.items():

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -6,6 +6,8 @@ from mongodb_store.message_store import MessageStoreProxy
 from soma_manager.srv import *
 #from tabulate import tabulate
 from prettytable import PrettyTable
+import json
+import os.path
 
 def create_analysis_for_type(type):
     print("making query")
@@ -55,16 +57,37 @@ def create_analysis_for_type(type):
 
     return rooms, nbr_queries, nbr_results
 
-if __name__ == '__main__':
+def get_metaroom_segment_stats(data_path):
+
+    with open(os.path.join(data_path, 'segments_summary.json')) as data_file:
+        data = json.load(data_file)
+
+    nbr_sweeps = data['value0']['nbr_sweeps']
+    nbr_segments = data['value0']['nbr_convex_segments']
+
+    return nbr_sweeps, nbr_segments
+
+def run(data_path):
+
+    nbr_sweeps, nbr_segments = get_metaroom_segment_stats(data_path)
     db_rooms, db_nbr_queries, db_nbr_results = create_analysis_for_type("quasimodo_db_result")
     metaroom_rooms, metaroom_nbr_queries, metaroom_nbr_results = create_analysis_for_type("quasimodo_metaroom_result")
 
     t = PrettyTable(['Entity', 'Quasimodo Model DB Query', 'Quasimodo Metarooms Query'])
     t.add_row(['Number queries:', db_nbr_queries, metaroom_nbr_queries])
     t.add_row(['Number results:', db_nbr_results, metaroom_nbr_results])
+    t.add_row(['Indexed sweeps:', '-', nbr_sweeps])
+    t.add_row(['Indexed segments:', '-', nbr_segments])
     for k, v in db_rooms.items():
-        t.add_row([k, v, 0])
+        t.add_row([k, v, '-'])
     for k, v in metaroom_rooms.items():
-        t.add_row([k, 0, v])
+        t.add_row([k, '-', v])
 
     print t
+
+if __name__ == '__main__':
+
+    if len(sys.argv) < 2:
+        print "Please provide the semantic maps data path..."
+    else:
+        run(sys.argv[1])

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -58,11 +58,11 @@ def create_analysis_for_type(type):
     reversed_dict = {}
     for k, v in rooms.items():
         if v in reversed_dict:
-            v += 1
+            reversed_dict[v] += 1
         else:
-            v = 1
+            reversed_dict[v] = 1
 
-    return rooms, reversed_dict, nbr_results
+    return reversed_dict, nbr_queries, nbr_results
 
 def get_metaroom_segment_stats(data_path):
 

--- a/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
+++ b/quasimodo/quasimodo_retrieval/scripts/analyze_retrieval_queries.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+import rospy
 from soma_msgs.msg import SOMAObject
 from mongodb_store.message_store import MessageStoreProxy
 from soma_manager.srv import *
@@ -8,7 +9,7 @@ from prettytable import PrettyTable
 
 def create_analysis_for_type(type):
     print("making query")
-    soma_query = rospy.ServiceProxy('soma/query_db', SOMAQueryObjs)
+    soma_query = rospy.ServiceProxy('soma/query_objects', SOMAQueryObjs)
     print("done query")
 
     # Query all observations during the last 30 mins
@@ -40,12 +41,12 @@ def create_analysis_for_type(type):
 
         if x.metadata in queries:
             queries[x.metadata] += 1
-        else
+        else:
             queries[x.metadata] = 1
 
         if ids[0] in rooms:
             rooms[ids[0]] += 1
-        else
+        else:
             rooms[ids[0]] = 1
 
     nbr_queries = len(queries)
@@ -59,9 +60,9 @@ if __name__ == '__main__':
     t = PrettyTable(['Entity', 'Quasimodo Model DB Query', 'Quasimodo Metarooms Query'])
     t.add_row(['Number queries:', db_nbr_queries, metaroom_nbr_queries])
     t.add_row(['Number results:', db_nbr_results, metaroom_nbr_results])
-    for k, v in db_rooms.items()
+    for k, v in db_rooms.items():
         t.add_row([k, v, 0])
-    for k, v in metaroom_rooms.items()
+    for k, v in metaroom_rooms.items():
         t.add_row([k, 0, v])
 
     print t

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
@@ -25,6 +25,22 @@ using PointT = pcl::PointXYZRGB;
 using CloudT = pcl::PointCloud<PointT>;
 using HistT = pcl::Histogram<250>;
 
+string random_string( size_t length )
+{
+    auto randchar = []() -> char
+    {
+        const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+        const size_t max_index = (sizeof(charset) - 1);
+        return charset[ rand() % max_index ];
+    };
+    string str(length,0);
+    generate_n(str.begin(), length, randchar);
+    return str;
+}
+
 class logging_server {
 public:
     ros::NodeHandle n;
@@ -42,16 +58,22 @@ public:
     {
         soma_manager::SOMAInsertObjs::Request soma_req;
 
+        string search_id = random_string(6);
+
         size_t N = res.result.retrieved_clouds.size();
         soma_req.objects.resize(N);
         for (size_t i = 0; i < N; ++i) {
-            cout << "Retrieved image paths length: " << res.result.retrieved_image_paths.size() << endl;
+            //cout << "Retrieved image paths length: " << res.result.retrieved_image_paths.size() << endl;
             boost::filesystem::path sweep_xml = boost::filesystem::path(res.result.retrieved_image_paths[i].strings[0]).parent_path() / "room.xml";
-            cout << "Sweep xml: " << sweep_xml.string() << endl;
+            //cout << "Sweep xml: " << sweep_xml.string() << endl;
             boost::posix_time::time_duration diff;
             if (sweep_xml.parent_path().parent_path().stem() == "temp") {
                 soma_req.objects[i].cloud = res.result.retrieved_clouds[i];
-                diff = boost::posix_time::time_duration(10, 10, 10); // just placeholder for now, should get real timestamp and transform from mongodb object
+                //diff = boost::posix_time::time_duration(10, 10, 10); // just placeholder for now, should get real timestamp and transform from mongodb object
+                boost::posix_time::ptime start_time = boost::posix_time::second_clock::local_time();
+                boost::posix_time::ptime time_t_epoch(boost::gregorian::date(1970,1,1));
+                diff = start_time - time_t_epoch;
+                soma_req.objects[i].type = "quasimodo_db_result";
             }
             else {
                 auto data = SimpleXMLParser<PointT>::loadRoomFromXML(sweep_xml.string(), vector<string>({"RoomIntermediateCloud"}), false, false);
@@ -62,12 +84,15 @@ public:
                 cout << "Intermediate room cloud transforms length: " << data.vIntermediateRoomCloudTransforms.size() << endl;
                 tf::transformTFToEigen(data.vIntermediateRoomCloudTransforms[0], AT);
                 pcl_ros::transformPointCloud(AT.matrix().cast<float>(), res.result.retrieved_clouds[i], soma_req.objects[i].cloud);
+                soma_req.objects[i].type = "quasimodo_metaroom_result";
             }
             //soma_req.objects[i].cloud = res.result.retrieved_clouds[i];
             cout << "Retrieved initial poses length: " << res.result.retrieved_initial_poses.size() << endl;
             soma_req.objects[i].pose = res.result.retrieved_initial_poses[i].poses[0];
             soma_req.objects[i].logtimestamp = diff.total_seconds(); //   ros::Time::now().sec;
             soma_req.objects[i].id = res.result.retrieved_image_paths[i].strings[0];
+            soma_req.objects[i].config = "quasimodo_retrieval_result";
+            soma_req.objects[i].metadata = search_id;
         }
 
         std::sort(soma_req.objects.begin(), soma_req.objects.end(), [](const soma_msgs::SOMAObject& o1, const soma_msgs::SOMAObject& o2) {
@@ -89,14 +114,14 @@ public:
         soma_manager::SOMAInsertObjs::Response soma_resp;
         try {
             if (soma_service.call(soma_req, soma_resp)) {
-                cout << "Successfully inserted queries!" << endl;
+                cout << "Quasimodo logging server: successfully inserted queries!" << endl;
             }
             else {
-                cout << "Could not connect to SOMA!" << endl;
+                cout << "Quasimodo logging server: Could not connect to SOMA!" << endl;
             }
         }
         catch (exception& e) {
-            cout << "Soma service called failed with: " << e.what() << endl;
+            cout << "Quasimodo logging server: Soma service called failed with: " << e.what() << endl;
         }
 
         /*

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
@@ -16,7 +16,7 @@
 
 // for logging to soma in mongodb
 #include <soma_msgs/SOMAObject.h>
-#include <soma_manager/SOMA2InsertObjs.h>
+#include <soma_manager/SOMAInsertObjs.h>
 #include <mongodb_store/MongoInsert.h>
 
 using namespace std;
@@ -40,7 +40,7 @@ public:
 
     void callback(const quasimodo_msgs::retrieval_query_result& res)
     {
-        soma_manager::SOMA2InsertObjs::Request soma_req;
+        soma_manager::SOMAInsertObjs::Request soma_req;
 
         size_t N = res.result.retrieved_clouds.size();
         soma_req.objects.resize(N);

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_logging_server.cpp
@@ -14,8 +14,8 @@
 #include <tf_conversions/tf_eigen.h>
 #include <eigen_conversions/eigen_msg.h>
 
-// for logging to soma2 in mongodb
-#include <soma2_msgs/SOMA2Object.h>
+// for logging to soma in mongodb
+#include <soma_msgs/SOMAObject.h>
 #include <soma_manager/SOMA2InsertObjs.h>
 #include <mongodb_store/MongoInsert.h>
 
@@ -70,7 +70,7 @@ public:
             soma_req.objects[i].id = res.result.retrieved_image_paths[i].strings[0];
         }
 
-        std::sort(soma_req.objects.begin(), soma_req.objects.end(), [](const soma2_msgs::SOMA2Object& o1, const soma2_msgs::SOMA2Object& o2) {
+        std::sort(soma_req.objects.begin(), soma_req.objects.end(), [](const soma_msgs::SOMAObject& o1, const soma_msgs::SOMAObject& o2) {
             return o1.logtimestamp < o2.logtimestamp;
         });
 
@@ -85,8 +85,8 @@ public:
         soma_req.objects[N].id = "retrieval_query";
         */
 
-        ros::ServiceClient soma_service = n.serviceClient<soma_manager::SOMA2InsertObjs>("/soma2/insert_objects");
-        soma_manager::SOMA2InsertObjs::Response soma_resp;
+        ros::ServiceClient soma_service = n.serviceClient<soma_manager::SOMAInsertObjs>("/soma/insert_objects");
+        soma_manager::SOMAInsertObjs::Response soma_resp;
         try {
             if (soma_service.call(soma_req, soma_resp)) {
                 cout << "Successfully inserted queries!" << endl;
@@ -103,7 +103,7 @@ public:
         mongodb_store::MongoInsert::Request db_req;
         //db_req.
 
-        ros::ServiceClient db_service = n.serviceClient<mongodb_store::MongoInsert>("/soma2/insert_objects");
+        ros::ServiceClient db_service = n.serviceClient<mongodb_store::MongoInsert>("/soma/insert_objects");
         mongodb_store::MongoInsert::Response db_resp;
         if (db_service.call(db_req, db_resp)) {
             cout << "Successfully inserted queries!" << endl;

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -195,7 +195,7 @@ public:
         }
 
         cout << "Re-loading new vocabulary with timestamp: " << temp_summary.last_updated << endl;
-        ros::Duration(0.2).sleep(); // sleep for a little bit to make sure the vocabulary is saved
+        ros::Duration(0.5).sleep(); // sleep for a little bit to make sure the vocabulary is saved
 
         summary = temp_summary;
         vt = grouped_vocabulary_tree<HistT, 8>();

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -151,6 +151,9 @@ public:
         if (summary.last_updated == temp_summary.last_updated) {
             return false;
         }
+
+        cout << "Re-loading new vocabulary with timestamp: " << temp_summary.last_updated << endl;
+
         summary = temp_summary;
         vt = grouped_vocabulary_tree<HistT, 8>();
         dynamic_object_retrieval::load_vocabulary(vt, vocabulary_path);

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -576,6 +576,7 @@ public:
 
         vector<float> scores;
         vector<int> indices;
+        vector<int> vocabulary_ids;
         for (auto s : results.first) {
             boost::filesystem::path segment_path = base_path(s.first);
             string name = segment_path.stem().string();
@@ -589,6 +590,7 @@ public:
                 indices.push_back(index);
             }
             scores.push_back(s.second.score);
+            vocabulary_ids.push_back(s.second.index);
         }
 
         vector<vector<Eigen::Matrix4f>, Eigen::aligned_allocator<Eigen::Matrix4f > > initial_poses;
@@ -620,7 +622,7 @@ public:
 
 
         tf::transformTFToMsg(room_transform, query_room_transform);
-        result = construct_msgs(retrieved_clouds, initial_poses, images, depths, masks, paths, scores, indices);
+        result = construct_msgs(retrieved_clouds, initial_poses, images, depths, masks, paths, scores, indices, vocabulary_ids);
         for (int i = 0; i < retrieved_clouds.size(); ++i) {
             sensor_msgs::PointCloud2 cloud_msg = result.retrieved_clouds[i];
             cloud_msg.header.stamp = ros::Time::now();
@@ -708,7 +710,8 @@ public:
                                                     const vector<vector<cv::Mat> >& masks,
                                                     const vector<vector<string> >& paths,
                                                     const vector<float>& scores,
-                                                    const vector<int>& indices)
+                                                    const vector<int>& indices,
+                                                    const vector<int>& vocabulary_ids)
     {
         quasimodo_msgs::retrieval_result res;
 
@@ -734,6 +737,7 @@ public:
         res.retrieved_image_paths.resize(number_retrieved);
         res.retrieved_distance_scores.resize(number_retrieved);
         res.segment_indices.resize(number_retrieved);
+        res.vocabulary_ids.resize(number_retrieved);
 
         for (int i = 0; i < number_retrieved; ++i) {
             pcl::toROSMsg(*clouds[i], res.retrieved_clouds[i]);
@@ -754,6 +758,7 @@ public:
             }
             res.retrieved_distance_scores[i] = scores[i];
             res.segment_indices[i].ints.push_back(indices[i]);
+            res.vocabulary_ids[i] = vocabulary_ids[i];
         }
 
         return res;

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -91,6 +91,8 @@ public:
         pn.param<std::string>("input", retrieval_input, std::string("/models/query"));
 
         summary.load(vocabulary_path);
+        cout << "Loaded summary from: " << (vocabulary_path / "vocabulary_summary.json").string() << endl;
+        cout << "With data path: " << summary.noise_data_path << endl;
 
         // Load and save data in the relative format
         /*

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -405,6 +405,11 @@ public:
         // This is just to make sure that we have valid results even when some meta rooms have been deleted
         size_t counter = 0;
         while (counter < number_query) {
+            // assume that everything in mongodb is kept
+            if (results.first[counter].first.stem().string() == "surfel_map") {
+                ++counter;
+                continue;
+            }
             if (!boost::filesystem::exists(results.first[counter].first)) {
                 auto iter = std::find_if(results.first.begin()+counter, results.first.end(), [](const pair<boost::filesystem::path, vocabulary_tree<HistT, 8>::result_type>& res) {
                     return boost::filesystem::exists(res.first);
@@ -527,6 +532,11 @@ public:
         // This is just to make sure that we have valid results even when some meta rooms have been deleted
         size_t counter = 0;
         while (counter < number_query) {
+            // assume that everything in mongodb is kept
+            if (results.first[counter].first.stem().string() == "surfel_map") {
+                ++counter;
+                continue;
+            }
             if (!boost::filesystem::exists(results.first[counter].first)) {
                 auto iter = std::find_if(results.first.begin()+counter, results.first.end(), [](const pair<boost::filesystem::path, vocabulary_tree<HistT, 8>::result_type>& v) {
                     return boost::filesystem::exists(v.first);

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -239,7 +239,7 @@ public:
         //int height = 480;
         //int width = 640;
 
-        string mongodb_id = sweep_xml.parent_path().stem().string();
+        string mongodb_id = sweep_xml.parent_path().parent_path().stem().string();
         //string mongodb_uri = string("/world_state/quasimodo/") / mongodb_id;
 
         mongodb_store::MessageStoreProxy message_store_quasimodo(n, "quasimodo", "world_state");
@@ -596,7 +596,7 @@ public:
         for (int i = 0; i < retrieved_clouds.size(); ++i) {
             string name = results.first[i].first.stem().string();
             cout << name << endl;
-            if (name != "surfel_map") {
+            if (name != "segment") {
                 auto data = SimpleXMLParser<PointT>::loadRoomFromXML(sweep_paths[i].string(), std::vector<std::string>{"RoomIntermediateCloud"}, false, false);
                 room_transform = data.vIntermediateRoomCloudTransforms[0];
                 room_transform.setOrigin(tf::Vector3(0.0, 0.0, 0.0));
@@ -615,7 +615,7 @@ public:
             boost::filesystem::path segment_path = s.first;
             string name = segment_path.stem().string();
             cout << name << endl;
-            if (name == "surfel_map") { // for the mongodb results
+            if (name == "segment") { // for the mongodb results
                 indices.push_back(-1);
             }
             else { // for the metric map results

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -47,6 +47,7 @@ public:
     ros::Publisher pub;
     ros::ServiceServer service;
     ros::Publisher keypoint_pub;
+    ros::Publisher pubs[10];
     ros::Subscriber sub;
 
     dynamic_reconfigure::Server<quasimodo_retrieval::parametersConfig> server;
@@ -117,6 +118,9 @@ public:
 
         pub = n.advertise<quasimodo_msgs::retrieval_query_result>(retrieval_output, 1);
         keypoint_pub = n.advertise<sensor_msgs::PointCloud2>("/models/keypoints", 1);
+        for (size_t i = 0; i < 10; ++i) {
+            pubs[i] = n.advertise<sensor_msgs::PointCloud2>(string("/retrieval_cloud/") + to_string(i), 1, true);
+        }
         sub = n.subscribe(retrieval_input, 10, &retrieval_node::run_retrieval, this);
         service = n.advertiseService("/query_normal_cloud", &retrieval_node::service_callback, this);
         /*
@@ -151,6 +155,7 @@ public:
         for (int i = 0; i < transforms.size(); ++i) {
             cv::Mat mask = cv::Mat::zeros(height, width, CV_8UC1);
             int sum = 0;
+            pair<cv::Mat, cv::Mat> intermediate_images = sweep_get_rgbd_at(sweep_xml, i);
             for (const PointT& p : cloud->points) {
                 Eigen::Vector4f q = transforms[i]*p.getVector4fMap();
                 if (q(2)/q(3) < 0) {
@@ -160,6 +165,12 @@ public:
                 int x = int(r(0)/r(2));
                 int y = int(r(1)/r(2));
                 if (x >= width || x < 0 || y >= height || y < 0) {
+                    continue;
+                }
+                float depth = 0.001f*float(intermediate_images.second.at<uint16_t>(y, x));
+                //cout << "Depth: " << depth << endl;
+                //cout << "Point depth: " << q(2)/q(3) << endl;
+                if (fabs(depth - q(2)) > 0.02f) {
                     continue;
                 }
                 mask.at<uint8_t>(y, x) = 255;
@@ -178,7 +189,6 @@ public:
 
 
             get<0>(images).push_back(mask);
-            pair<cv::Mat, cv::Mat> intermediate_images = sweep_get_rgbd_at(sweep_xml, i);
             get<1>(images).push_back(intermediate_images.first);
             get<2>(images).push_back(intermediate_images.second);
             //get<1>(images).push_back(benchmark_retrieval::sweep_get_rgb_at(sweep_xml, i));
@@ -426,7 +436,8 @@ public:
         cam_model.fromCameraInfo(query_msg->camera);
         cv::Matx33d cvK = cam_model.intrinsicMatrix();
         Eigen::Matrix3f K = Eigen::Map<Eigen::Matrix3d>(cvK.val).cast<float>();
-        K << 525.0f, 0.0f, 319.5f, 0.0f, 525.0f, 239.5f, 0.0f, 0.0f, 1.0f; // should be removed if Johan returns K?
+        K << 528.0f, 0.0f, 317.0f, 0.0f, 525.0f, 245.0f, 0.0f, 0.0f, 1.0f; // surfelize_it intrinsics
+       // K << 525.0f, 0.0f, 319.5f, 0.0f, 525.0f, 239.5f, 0.0f, 0.0f, 1.0f; // should be removed if Johan returns K?
 
         HistCloudT::Ptr features(new HistCloudT);
         CloudT::Ptr keypoints(new CloudT);
@@ -518,6 +529,12 @@ public:
 
         tf::transformTFToMsg(room_transform, result.query.room_transform);
         result.result = construct_msgs(retrieved_clouds, initial_poses, images, depths, masks, paths, scores, indices);
+        for (int i = 0; i < retrieved_clouds.size(); ++i) {
+            sensor_msgs::PointCloud2 cloud_msg = result.result.retrieved_clouds[i];
+            cloud_msg.header.stamp = ros::Time::now();
+            cloud_msg.header.frame_id = "/map";
+            pubs[i].publish(cloud_msg);
+        }
         pub.publish(result);
 
         cout << "Finished retrieval..." << endl;

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_retrieval_node.cpp
@@ -45,6 +45,7 @@ class retrieval_node {
 public:
     ros::NodeHandle n;
     ros::Publisher pub;
+    ros::Publisher img_pub;
     ros::ServiceServer service;
     ros::Publisher keypoint_pub;
     ros::Subscriber sub;
@@ -116,6 +117,7 @@ public:
         server.setCallback(boost::bind(&retrieval_node::parameters_callback, this, _1, _2));
 
         pub = n.advertise<quasimodo_msgs::retrieval_query_result>(retrieval_output, 1);
+        img_pub = n.advertise<sensor_msgs::Image>("/quasimodo_retrieval/raw_visualization", 1, true);
         keypoint_pub = n.advertise<sensor_msgs::PointCloud2>("/models/keypoints", 1);
         sub = n.subscribe(retrieval_input, 10, &retrieval_node::run_retrieval, this);
         service = n.advertiseService("/query_normal_cloud", &retrieval_node::service_callback, this);
@@ -403,6 +405,8 @@ public:
         }
 
         res.result = construct_msgs(retrieved_clouds, initial_poses, images, depths, masks, paths, scores, indices);
+        sensor_msgs::Image img_msg = construct_results_image(images);
+        img_pub.publish(img_msg);
 
         cout << "Finished retrieval..." << endl;
     }
@@ -519,6 +523,8 @@ public:
         tf::transformTFToMsg(room_transform, result.query.room_transform);
         result.result = construct_msgs(retrieved_clouds, initial_poses, images, depths, masks, paths, scores, indices);
         pub.publish(result);
+        sensor_msgs::Image img_msg = construct_results_image(images);
+        img_pub.publish(img_msg);
 
         cout << "Finished retrieval..." << endl;
     }
@@ -545,6 +551,26 @@ public:
         cv_pub_ptr->image = cv_image;
         cv_pub_ptr->encoding = "mono8";
         ros_image = *cv_pub_ptr->toImageMsg();
+    }
+
+    sensor_msgs::Image construct_results_image(const vector<vector<cv::Mat> >& images)
+    {
+        int width = 640;
+        int height = 480;
+
+        pair<int, int> sizes = make_pair(2, 5);
+
+        cv::Mat visualization = cv::Mat::zeros(height*sizes.first, width*sizes.second, CV_8UC3);
+        for (size_t i = 0; i < images.size(); ++i) {
+            size_t offset_height = i / sizes.second;
+            size_t offset_width = i % sizes.second;
+            images[i][0].copyTo(visualization(cv::Rect(offset_width*width, offset_height*height, width, height)));
+        }
+
+        sensor_msgs::Image img_msg;
+        convert_to_img_msg(visualization, img_msg);
+
+        return img_msg;
     }
 
     quasimodo_msgs::retrieval_result construct_msgs(const vector<CloudT::Ptr>& clouds,

--- a/quasimodo/quasimodo_retrieval/src/quasimodo_visualize_retrieval_cloud.cpp
+++ b/quasimodo/quasimodo_retrieval/src/quasimodo_visualize_retrieval_cloud.cpp
@@ -1,0 +1,151 @@
+#include <dynamic_object_retrieval/summary_iterators.h>
+#include <dynamic_object_retrieval/dynamic_retrieval.h>
+#include <object_3d_benchmark/benchmark_retrieval.h>
+
+#include <metaroom_xml_parser/load_utilities.h>
+#include <dynamic_object_retrieval/definitions.h>
+#include <object_3d_retrieval/pfhrgb_estimation.h>
+
+#include <k_means_tree/k_means_tree.h>
+#include <vocabulary_tree/vocabulary_tree.h>
+#include <grouped_vocabulary_tree/grouped_vocabulary_tree.h>
+
+#include "ros/ros.h"
+#include "quasimodo_msgs/retrieval_query_result.h"
+#include "quasimodo_msgs/model.h"
+#include <pcl_ros/point_cloud.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/image_encodings.h>
+#include <tf_conversions/tf_eigen.h>
+#include <eigen_conversions/eigen_msg.h>
+
+using namespace std;
+
+using PointT = pcl::PointXYZRGB;
+using CloudT = pcl::PointCloud<PointT>;
+using HistT = pcl::Histogram<250>;
+using HistCloudT = pcl::PointCloud<HistT>;
+using LabelT = semantic_map_load_utilties::LabelledData<PointT>;
+
+POINT_CLOUD_REGISTER_POINT_STRUCT (HistT,
+                                   (float[N], histogram, histogram)
+)
+
+class retrieval_cloud_visualizer {
+public:
+    ros::NodeHandle n;
+    ros::Subscriber sub;
+    ros::Publisher pubs[10];
+
+    string input;
+
+    retrieval_cloud_visualizer(const std::string& name)
+    {
+        ros::NodeHandle pn("~");
+
+        pn.param<std::string>("input", input, std::string("/retrieval_result"));
+
+        sub = n.subscribe(input, 1, &retrieval_cloud_visualizer::callback, this);
+
+        for (size_t i = 0; i < 10; ++i) {
+            pubs[i] = n.advertise<sensor_msgs::PointCloud2>(string("/retrieval_cloud/") + to_string(i), 1, true);
+        }
+    }
+
+    CloudT::Ptr construct_cloud(cv::Mat& rgb, cv::Mat& depth, cv::Mat& mask, const Eigen::Matrix3f& K, const Eigen::Matrix4f& T)
+    {
+        int height = rgb.rows;
+        int width = rgb.cols;
+
+        CloudT::Ptr cloud(new CloudT);
+        for (int i = 0; i < height; ++i) {
+            for (int j = 0; j < width; ++j) {
+                if (mask.at<uchar>(i, j) == 0) {
+                    continue;
+                }
+                float d = 0.0002f*float(depth.at<uint16_t>(i, j));
+                Eigen::Vector3f ep(float(j), float(i), 1.0f);
+                ep = K.inverse()*ep;
+                ep = d/ep(2)*ep;
+                PointT p;
+                p.getVector3fMap() = ep;
+                cv::Vec3b colors = rgb.at<cv::Vec3b>(i, j);
+                p.r = colors[0]; p.g = colors[1]; p.b = colors[2];
+                cloud->push_back(p);
+            }
+        }
+        CloudT::Ptr temp_cloud(new CloudT);
+        pcl::transformPointCloud(*cloud, *temp_cloud, T);
+        return temp_cloud;
+    }
+
+    void callback(const quasimodo_msgs::retrieval_query_result& result)
+    {
+        int m = result.result.retrieved_clouds.size(); // 10!
+
+        for (int j = 0; j < m; ++j) {
+            int n = result.result.retrieved_images[j].images.size();
+            CloudT::Ptr cloud(new CloudT);
+
+            for (int i = 0; i < n; ++i) {
+                Eigen::Matrix3f K; // = Eigen::Map<Eigen::Matrix3d>(cvK.val).cast<float>();
+                K << 525.0f, 0.0f, 319.5f, 0.0f, 525.0f, 239.5f, 0.0f, 0.0f, 1.0f;
+
+                Eigen::Affine3d e;
+                tf::poseMsgToEigen(result.result.retrieved_initial_poses[j].poses[i], e);
+                Eigen::Matrix4f T = e.matrix().cast<float>();
+
+                cv_bridge::CvImagePtr cv_ptr;
+                try {
+                    cv_ptr = cv_bridge::toCvCopy(result.result.retrieved_images[j].images[j], sensor_msgs::image_encodings::BGR8);
+                }
+                catch (cv_bridge::Exception& e) {
+                    ROS_ERROR("cv_bridge exception: %s", e.what());
+                    exit(-1);
+                }
+
+                cv_bridge::CvImagePtr cv_depth_ptr;
+                try {
+                    cv_depth_ptr = cv_bridge::toCvCopy(result.result.retrieved_depths[j].images[j], sensor_msgs::image_encodings::MONO16);
+                }
+                catch (cv_bridge::Exception& e) {
+                    ROS_ERROR("cv_bridge exception: %s", e.what());
+                    exit(-1);
+                }
+
+                cv_bridge::CvImagePtr cv_mask_ptr;
+                try {
+                    cv_mask_ptr = cv_bridge::toCvCopy(result.result.retrieved_masks[j].images[j], sensor_msgs::image_encodings::MONO8);
+                }
+                catch (cv_bridge::Exception& e) {
+                    ROS_ERROR("cv_bridge exception: %s", e.what());
+                    exit(-1);
+                }
+
+                CloudT::Ptr frame_cloud = construct_cloud(cv_ptr->image, cv_depth_ptr->image, cv_mask_ptr->image, K, T);
+                *cloud += *frame_cloud;
+            }
+
+            sensor_msgs::PointCloud2 msg_cloud;
+            pcl::toROSMsg(*cloud, msg_cloud);
+            msg_cloud.header.stamp = ros::Time::now();
+            msg_cloud.header.frame_id = "/map";
+            //tf::transformTFToMsg(room_transform, res.query.room_transform);
+            pubs[j].publish(msg_cloud);
+
+        }
+    }
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "quasimodo_visualize_retrieval_cloud");
+
+    retrieval_cloud_visualizer vrc(ros::this_node::getName());
+
+    ros::spin();
+
+    return 0;
+}
+

--- a/quasimodo/retrieval_processing/launch/processing.launch
+++ b/quasimodo/retrieval_processing/launch/processing.launch
@@ -1,26 +1,30 @@
 <launch>
     <arg name="data_path" default="/home/strands/.semanticMap"/>
     <arg name="add_previous_maps" default="false"/>
+    <arg name="bypass_segmentation" default="false"/>
+    <arg name="bypass_features" default="false"/>
+    <arg name="bypass_vocabulary" default="false"/>
+    <arg name="bypass_surfelize" default="false"/>
 
     <node pkg="surfelize_it" type="run_map_processor.py" name="run_map_processor" output="screen" respawn="true"/>
     <node pkg="retrieval_processing" type="retrieval_segmentation" name="retrieval_segmentation" output="screen" respawn="false">
         <param name="threshold" value="0.3"/>
         <param name="data_path" value="$(arg data_path)"/>
-        <param name="bypass" value="false" type="bool"/>
+        <param name="bypass" value="$(arg bypass_segmentation)" type="bool"/>
     </node>
     <node pkg="retrieval_processing" type="retrieval_features" name="retrieval_features" output="screen" respawn="false">
-        <param name="bypass" value="false" type="bool"/>
+        <param name="bypass" value="$(arg bypass_features)" type="bool"/>
     </node>
     <node pkg="retrieval_processing" type="retrieval_vocabulary" name="retrieval_vocabulary" output="screen" respawn="false">
         <param name="vocabulary_path" value="$(arg data_path)/vocabulary"/>
         <param name="data_path" value="$(arg data_path)"/>
         <param name="min_training_sweeps" value="20"/>
-        <param name="bypass" value="false" type="bool"/>
+        <param name="bypass" value="$(arg bypass_vocabulary)" type="bool"/>
     </node>
     <group if="$(arg add_previous_maps)">
         <node pkg="retrieval_processing" type="retrieval_simulate_observations" name="retrieval_simulate_observations" output="screen" respawn="false">
             <param name="data_path" value="$(arg data_path)"/>
-            <param name="bypass_surfelize" value="false" type="bool"/>
+            <param name="bypass_surfelize" value="$(arg bypass_surfelize)" type="bool"/>
         </node>
     </group>
 </launch>

--- a/quasimodo/retrieval_processing/launch/processing.launch
+++ b/quasimodo/retrieval_processing/launch/processing.launch
@@ -8,15 +8,21 @@
     <arg name="bypass_surfelize" default="false"/>
 
     <node pkg="surfelize_it" type="run_map_processor.py" name="run_map_processor" output="screen" respawn="true"/>
-    <node pkg="retrieval_processing" type="retrieval_segmentation" name="retrieval_segmentation" output="screen" respawn="false">
+    <node pkg="retrieval_processing" type="retrieval_segmentation" name="retrieval_segmentation" output="screen" respawn="true">
         <param name="threshold" value="0.3"/>
         <param name="data_path" value="$(arg data_path)"/>
         <param name="bypass" value="$(arg bypass_segmentation)" type="bool"/>
     </node>
-    <node pkg="retrieval_processing" type="retrieval_features" name="retrieval_features" output="screen" respawn="false">
+    <!-- This one is for the meta room processing stuff -->
+    <node pkg="retrieval_processing" type="retrieval_features" name="retrieval_features" output="screen" respawn="true">
         <param name="bypass" value="$(arg bypass_features)" type="bool"/>
+        <param name="service" value="ignore"/>
     </node>
-    <node pkg="retrieval_processing" type="retrieval_vocabulary" name="retrieval_vocabulary" output="screen" respawn="false">
+    <!-- And this is for the model object part -->
+    <node pkg="retrieval_processing" type="retrieval_features" name="retrieval_features_service" output="screen" respawn="true">
+        <param name="input" value="ignore"/>
+    </node>
+    <node pkg="retrieval_processing" type="retrieval_vocabulary" name="retrieval_vocabulary" output="screen" respawn="true">
         <param name="vocabulary_path" value="$(arg data_path)/vocabulary"/>
         <param name="data_path" value="$(arg data_path)"/>
         <param name="min_training_sweeps" value="100"/>

--- a/quasimodo/retrieval_processing/launch/processing.launch
+++ b/quasimodo/retrieval_processing/launch/processing.launch
@@ -1,6 +1,7 @@
 <launch>
-    <arg name="data_path" default="/home/strands/.semanticMap"/>
-    <arg name="add_previous_maps" default="false"/>
+    <arg name="data_path" default="/home/nbore/Data/KTH_longterm_dataset_labels"/>
+    <arg name="add_previous_maps" default="true"/>
+    <arg name="start_add_map_ind" default="-1"/>
     <arg name="bypass_segmentation" default="false"/>
     <arg name="bypass_features" default="false"/>
     <arg name="bypass_vocabulary" default="false"/>
@@ -18,13 +19,14 @@
     <node pkg="retrieval_processing" type="retrieval_vocabulary" name="retrieval_vocabulary" output="screen" respawn="false">
         <param name="vocabulary_path" value="$(arg data_path)/vocabulary"/>
         <param name="data_path" value="$(arg data_path)"/>
-        <param name="min_training_sweeps" value="20"/>
+        <param name="min_training_sweeps" value="100"/>
         <param name="bypass" value="$(arg bypass_vocabulary)" type="bool"/>
     </node>
     <group if="$(arg add_previous_maps)">
         <node pkg="retrieval_processing" type="retrieval_simulate_observations" name="retrieval_simulate_observations" output="screen" respawn="false">
             <param name="data_path" value="$(arg data_path)"/>
             <param name="bypass_surfelize" value="$(arg bypass_surfelize)" type="bool"/>
+            <param name="start_add_map_ind" value="$(arg start_add_map_ind)"/>
         </node>
     </group>
 </launch>

--- a/quasimodo/retrieval_processing/src/retrieval_features.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_features.cpp
@@ -141,11 +141,13 @@ void test_compute_features(HistCloudT::Ptr& features, CloudT::Ptr& keypoints, Cl
 */
 
 bool features_service(quasimodo_msgs::transform_cloud::Request& req, quasimodo_msgs::transform_cloud::Response& resp)
-{
+{   
     double threshold = 0.4;
 
     SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
     pcl::fromROSMsg(req.cloud, *surfel_cloud);
+    cout << "Got service cloud with size: " << surfel_cloud->size() << endl;
+
     HistCloudT::Ptr desc_cloud(new HistCloudT);
     CloudT::Ptr kp_cloud(new CloudT);
 
@@ -165,6 +167,8 @@ bool features_service(quasimodo_msgs::transform_cloud::Request& req, quasimodo_m
         cloud->push_back(p);
         normals->push_back(n);
     }
+    cout << "Service points after confidence " << threshold << ": " << cloud->size() << endl;
+
     dynamic_object_retrieval::compute_features(desc_cloud, kp_cloud, cloud, normals);
     pcl::toROSMsg(*desc_cloud, resp.cloud1);
     pcl::toROSMsg(*kp_cloud, resp.cloud2);

--- a/quasimodo/retrieval_processing/src/retrieval_features.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_features.cpp
@@ -194,6 +194,11 @@ void features_callback(const std_msgs::String::ConstPtr& msg)
         boost::filesystem::path keypoint_path;
         tie(segment, feature_path, keypoint_path) = tup;
 
+        if (boost::filesystem::exists(feature_path) && boost::filesystem::exists(keypoint_path)) {
+            cout << "Features " << feature_path.string() << " already exist, finishing sweep " << msg->data << "..." << endl;
+            break;
+        }
+
         HistCloudT::Ptr desc_cloud(new HistCloudT);
         CloudT::Ptr kp_cloud(new CloudT);
         dynamic_object_retrieval::compute_features(desc_cloud, kp_cloud, segment, surfel_map);

--- a/quasimodo/retrieval_processing/src/retrieval_features.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_features.cpp
@@ -15,6 +15,9 @@
 #include <metaroom_xml_parser/load_utilities.h>
 #include <dynamic_object_retrieval/definitions.h>
 
+#include <quasimodo_msgs/transform_cloud.h>
+#include <pcl_ros/point_cloud.h>
+
 #include <ros/ros.h>
 #include <std_msgs/String.h>
 
@@ -35,6 +38,7 @@ using SurfelT = SurfelType;
 using SurfelCloudT = pcl::PointCloud<SurfelT>;
 
 ros::Publisher pub;
+ros::ServiceServer service;
 
 /*
 void test_compute_features(HistCloudT::Ptr& features, CloudT::Ptr& keypoints, CloudT::Ptr& cloud,
@@ -136,6 +140,38 @@ void test_compute_features(HistCloudT::Ptr& features, CloudT::Ptr& keypoints, Cl
 }
 */
 
+bool features_service(quasimodo_msgs::transform_cloud::Request& req, quasimodo_msgs::transform_cloud::Response& resp)
+{
+    double threshold = 0.4;
+
+    SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
+    pcl::fromROSMsg(req.cloud, *surfel_cloud);
+    HistCloudT::Ptr desc_cloud(new HistCloudT);
+    CloudT::Ptr kp_cloud(new CloudT);
+
+    NormalCloudT::Ptr normals(new NormalCloudT);
+    CloudT::Ptr cloud(new CloudT);
+    cloud->reserve(surfel_cloud->size());
+    normals->reserve(surfel_cloud->size());
+    for (const SurfelT& s : surfel_cloud->points) {
+        if (s.confidence < threshold) {
+            continue;
+        }
+        PointT p;
+        p.getVector3fMap() = s.getVector3fMap();
+        p.rgba = s.rgba;
+        NormalT n;
+        n.getNormalVector3fMap() = s.getNormalVector3fMap();
+        cloud->push_back(p);
+        normals->push_back(n);
+    }
+    dynamic_object_retrieval::compute_features(desc_cloud, kp_cloud, cloud, normals);
+    pcl::toROSMsg(*desc_cloud, resp.cloud1);
+    pcl::toROSMsg(*kp_cloud, resp.cloud2);
+
+    return true;
+}
+
 void features_callback(const std_msgs::String::ConstPtr& msg)
 {
     cout << "Received callback with path " << msg->data << endl;
@@ -200,6 +236,7 @@ int main(int argc, char** argv)
     pn.param<bool>("bypass", bypass, 0);
 
     pub = n.advertise<std_msgs::String>("/features_done", 1);
+    service = n.advertiseService("/retrieval_features_service", features_service);
 
     ros::Subscriber sub;
     if (bypass) {

--- a/quasimodo/retrieval_processing/src/retrieval_features.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_features.cpp
@@ -157,6 +157,9 @@ void features_callback(const std_msgs::String::ConstPtr& msg)
         HistCloudT::Ptr desc_cloud(new HistCloudT);
         CloudT::Ptr kp_cloud(new CloudT);
         dynamic_object_retrieval::compute_features(desc_cloud, kp_cloud, segment, surfel_map);
+
+        cout << "Saving " << feature_path.string() << " with " << desc_cloud->size() << " number of features. " << endl;
+
         //test_compute_features(desc_cloud, kp_cloud, segment, surfel_map);
         if (desc_cloud->empty()) {
             // push back one inf point on descriptors and keypoints

--- a/quasimodo/retrieval_processing/src/retrieval_features.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_features.cpp
@@ -141,7 +141,7 @@ void test_compute_features(HistCloudT::Ptr& features, CloudT::Ptr& keypoints, Cl
 */
 
 bool features_service(quasimodo_msgs::transform_cloud::Request& req, quasimodo_msgs::transform_cloud::Response& resp)
-{   
+{
     double threshold = 0.4;
 
     SurfelCloudT::Ptr surfel_cloud(new SurfelCloudT);
@@ -238,16 +238,20 @@ int main(int argc, char** argv)
     //pn.param<double>("threshold", threshold, 0.4);
     bool bypass;
     pn.param<bool>("bypass", bypass, 0);
+    string input;
+    pn.param<string>("input", input, "/segmentation_done");
+    string service_name;
+    pn.param<string>("service", service_name, "/retrieval_features_service");
 
     pub = n.advertise<std_msgs::String>("/features_done", 1);
-    service = n.advertiseService("/retrieval_features_service", features_service);
+    service = n.advertiseService(service_name, features_service);
 
     ros::Subscriber sub;
     if (bypass) {
-        sub = n.subscribe("/segmentation_done", 1, bypass_callback);
+        sub = n.subscribe(input, 1, bypass_callback);
     }
     else {
-        sub = n.subscribe("/segmentation_done", 1, features_callback);
+        sub = n.subscribe(input, 1, features_callback);
     }
 
     ros::spin();

--- a/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
@@ -124,6 +124,8 @@ bool maybe_append(const boost::filesystem::path& segments_path)
         data_summary.index_convex_segment_paths.push_back(segment_path.string());
     }
 
+    summary.save(segments_path);
+
     return true;
 }
 

--- a/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
@@ -106,6 +106,12 @@ bool maybe_append(const boost::filesystem::path& segments_path)
         std::stringstream ss;
         ss << "segment" << std::setw(4) << std::setfill('0') << 0;
         boost::filesystem::path segment_path = segments_path / (ss.str() + ".pcd");
+
+        cout << "Comparing segments of type: " << endl;
+        cout << data_summary.index_convex_segment_paths[0] << endl;
+        cout << "to" << endl;
+        cout << segment_path.string() << endl;
+
         if (std::find(data_summary.index_convex_segment_paths.begin(),
                       data_summary.index_convex_segment_paths.end(),
                       segment_path.string()) !=
@@ -124,7 +130,7 @@ bool maybe_append(const boost::filesystem::path& segments_path)
         data_summary.index_convex_segment_paths.push_back(segment_path.string());
     }
 
-    summary.save(segments_path);
+    data_summary.save(data_path);
 
     return true;
 }

--- a/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_segmentation.cpp
@@ -137,12 +137,12 @@ bool maybe_append(const boost::filesystem::path& segments_path)
 
 void segmentation_callback(const std_msgs::String::ConstPtr& msg)
 {
-    std_msgs::String done_msg;
-    done_msg.data = msg->data;
-
     data_summary.load(data_path);
 
-    boost::filesystem::path sweep_xml(msg->data);
+    boost::filesystem::path sweep_xml = boost::filesystem::canonical(msg->data);
+    std_msgs::String done_msg;
+    done_msg.data = sweep_xml.string();
+
     boost::filesystem::path surfel_path = sweep_xml.parent_path() / "surfel_map.pcd";
     boost::filesystem::path segments_path = sweep_xml.parent_path() / "convex_segments";
     if (boost::filesystem::exists(segments_path)) {

--- a/quasimodo/retrieval_processing/src/retrieval_simulate_observations.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_simulate_observations.cpp
@@ -94,6 +94,8 @@ int main(int argc, char** argv)
     pn.param<string>("data_path", data_path, "");
 
     pn.param<bool>("bypass_surfelize", bypass_surfelize, true);
+    int start_add_map_ind;
+    pn.param<int>("start_add_map_ind", start_add_map_ind, -1);
 
     sweep_xmls = semantic_map_load_utilties::getSweepXmls<PointT>(data_path, true);
     if (sweep_xmls.empty()) {
@@ -101,9 +103,13 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    sweep_ind = get_correct_sweep_ind(data_path); // 0;
+    if (start_add_map_ind < 0) {
+        sweep_ind = get_correct_sweep_ind(data_path);
+    }
+    else {
+        sweep_ind = start_add_map_ind;
+    }
     cout << "Starting at sweep number: " << sweep_ind << endl;
-
 
     if (bypass_surfelize) {
         cout << "Advertising " << "/surfelization_done" << endl;

--- a/quasimodo/retrieval_processing/src/retrieval_simulate_observations.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_simulate_observations.cpp
@@ -106,9 +106,11 @@ int main(int argc, char** argv)
 
 
     if (bypass_surfelize) {
+        cout << "Advertising " << "/surfelization_done" << endl;
         string_pub = n.advertise<std_msgs::String>("/surfelization_done", 1);
     }
     else {
+        cout << "Advertising " << "/local_metric_map/room_observations" << endl;
         room_pub = n.advertise<semantic_map::RoomObservation>("/local_metric_map/room_observations", 1);
     }
     ros::Subscriber sub = n.subscribe("/vocabulary_done", 1, callback);
@@ -116,11 +118,13 @@ int main(int argc, char** argv)
     ros::Duration(1.0).sleep();
 
     if (bypass_surfelize) {
+        cout << "Publishing initial simulated observation after surfelization: " << sweep_xmls[sweep_ind] << endl;
         std_msgs::String sweep_msg;
         sweep_msg.data = sweep_xmls[sweep_ind++];
         string_pub.publish(sweep_msg);
     }
     else {
+        cout << "Publishing initial simulated observation: " << sweep_xmls[sweep_ind] << endl;
         semantic_map::RoomObservation sweep_msg;
         sweep_msg.xml_file_name = sweep_xmls[sweep_ind++];
         room_pub.publish(sweep_msg);

--- a/quasimodo/retrieval_processing/src/retrieval_vocabulary.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_vocabulary.cpp
@@ -18,6 +18,11 @@
 #include <ros/ros.h>
 #include <std_msgs/String.h>
 
+#include <chrono>  // chrono::system_clock
+#include <ctime>   // localtime
+#include <sstream> // stringstream
+#include <iomanip> // put_time
+
 /**
  * The most reasonable thing to keep track of which metaroom folders that we have traversed
  * would be to create a new json file in the vocabulary folder with a list of all the sweeps
@@ -219,6 +224,11 @@ void train_vocabulary(const boost::filesystem::path& data_path)
     summary.nbr_annotated_segments = 0;
     summary.nbr_annotated_sweeps = 0;
 
+    auto now = std::chrono::system_clock::now();
+    auto in_time_t = std::chrono::system_clock::to_time_t(now);
+    char buffer [80];
+    std::strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", std::localtime(&in_time_t));
+    summary.last_updated = string(buffer);
     summary.save(vocabulary_path);
     uris.save(vocabulary_path);
     dynamic_object_retrieval::save_vocabulary(*vt, vocabulary_path);
@@ -323,6 +333,14 @@ bool vocabulary_service(quasimodo_msgs::index_cloud::Request& req, quasimodo_msg
     resp.id = summary.nbr_noise_segments;
     summary.nbr_noise_segments += 1;
     summary.nbr_noise_sweeps++;
+    auto now = std::chrono::system_clock::now();
+    auto in_time_t = std::chrono::system_clock::to_time_t(now);
+    char buffer [80];
+    std::strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", std::localtime(&in_time_t));
+    //std::stringstream ss;
+    //ss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %H:%M:%S");
+    //summary.last_updated = ss.str();
+    summary.last_updated = string(buffer);
     summary.save(vocabulary_path);
     dynamic_object_retrieval::save_vocabulary(*vt, vocabulary_path);
 
@@ -420,6 +438,11 @@ void vocabulary_callback(const std_msgs::String::ConstPtr& msg)
     summary.load(vocabulary_path);
     summary.nbr_noise_segments += counter;
     summary.nbr_noise_sweeps++;
+    auto now = std::chrono::system_clock::now();
+    auto in_time_t = std::chrono::system_clock::to_time_t(now);
+    char buffer [80];
+    std::strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", std::localtime(&in_time_t));
+    summary.last_updated = string(buffer);
     summary.save(vocabulary_path);
     dynamic_object_retrieval::save_vocabulary(*vt, vocabulary_path);
     // End of new part!

--- a/quasimodo/retrieval_processing/src/retrieval_vocabulary.cpp
+++ b/quasimodo/retrieval_processing/src/retrieval_vocabulary.cpp
@@ -241,14 +241,14 @@ pair<size_t, size_t> get_offsets_in_data(const boost::filesystem::path& sweep_pa
         // skips 0, that's ok
         if (sweep_i != last_sweep) {
             // this should actually work, right?
-            cout << sweep_path.string() << endl;
-            cout << segment_path.parent_path().parent_path().string() << endl;
+            //cout << sweep_path.string() << endl;
+            //cout << segment_path.parent_path().parent_path().string() << endl;
             if (sweep_path == segment_path.parent_path().parent_path()) {
                 cout << "Matching!" << endl;
                 return make_pair(sweep_i, counter);
             }
             else {
-                cout << "Not matching!" << endl;
+                //cout << "Not matching!" << endl;
             }
         }
 

--- a/strands_sweep_registration/include/strands_sweep_registration/pair3DError.h
+++ b/strands_sweep_registration/include/strands_sweep_registration/pair3DError.h
@@ -22,6 +22,7 @@ using ceres::Solve;
 
 class pair3DError : public SizedCostFunction<3, 6, 6, 4> {
 	public:
+    static bool optimizeCameraParams;
 	pair3DError(double sw, double sh, double sz,double dw, double dh, double dz, double weight);
 	~pair3DError();
 	bool Evaluate(double const* const* parameters, double* residuals, double** jacobians) const ;
@@ -34,7 +35,7 @@ class pair3DError : public SizedCostFunction<3, 6, 6, 4> {
 	double dh;
 	double dz;
 	double weight;
-    bool optimizeCameraParams;
+    //bool optimizeCameraParams;
     double information;
 };
 #endif

--- a/strands_sweep_registration/src/ProblemFrameConnection.cpp
+++ b/strands_sweep_registration/src/ProblemFrameConnection.cpp
@@ -30,8 +30,10 @@ void ProblemFrameConnection::addMatchesToProblem(ceres::Problem & problem, float
 		double sz	= src->keypoint_depth.at(src_kp_id);
 		double dz	= dst->keypoint_depth.at(dst_kp_id);			
 
-		CostFunction* err = new pair3DError(src_kp.pt.x,src_kp.pt.y,sz,dst_kp.pt.x,dst_kp.pt.y,dz,weight);
-		problem.AddResidualBlock(err, NULL, src_variable, dst_variable, params);
+        //CostFunction* err = new pair3DError(src_kp.pt.x,src_kp.pt.y,sz,dst_kp.pt.x,dst_kp.pt.y,dz,weight/pow(sz*sz+dz*dz,2));
+        CostFunction* err = new pair3DError(src_kp.pt.x,src_kp.pt.y,sz,dst_kp.pt.x,dst_kp.pt.y,dz,weight);
+        problem.AddResidualBlock(err, 0, src_variable, dst_variable, params);
+        problem.AddResidualBlock(err, new ceres::HuberLoss(0.1), src_variable, dst_variable, params);
 	}
 }
 

--- a/strands_sweep_registration/src/RobotContainer.cpp
+++ b/strands_sweep_registration/src/RobotContainer.cpp
@@ -118,6 +118,10 @@ RobotContainer::~RobotContainer(){
 
 void RobotContainer::initializeCamera(double fx, double fy, double cx, double cy, unsigned int w, unsigned int h)
 {
+    fx = 535;
+    fy = fx;
+    cx = double(w-1.0)/2.0;
+    cy = double(h-1.0)/2.0;
     std::cout<<"Initializing camera with parameters "<<fx<<"  "<<fy<<"  "<<cx<<"  "<<cy<<"  "<<w<<"  "<<h<<std::endl;
     width = w;
     height = h;
@@ -236,7 +240,7 @@ void RobotContainer::addToTraining(std::string path){
     */
 }
 
-std::vector< CostFunction * > getMatchesRansac(std::vector< ProblemFrameConnection * > & pc_vec, float weight = 1, float threshold = 0.005, int ransac_iter = 200000, int nr_points = 3){
+std::vector< CostFunction * > getMatchesRansac(std::vector< ProblemFrameConnection * > & pc_vec, float weight = 1, float threshold = 0.015, int ransac_iter = 200000, int nr_points = 3){
     std::vector<int> owner;
     std::vector<int> match_id;
     std::vector< Eigen::Vector3f > src_points;
@@ -430,6 +434,8 @@ std::vector<Eigen::Matrix4f> RobotContainer::runInitialTraining(){
         }
     }
 
+    Solve(options, &problem, &summary);
+    pair3DError::optimizeCameraParams = true;
     Solve(options, &problem, &summary);
     //std::cout << summary.FullReport() << "\n";
 

--- a/strands_sweep_registration/src/pair3DError.cpp
+++ b/strands_sweep_registration/src/pair3DError.cpp
@@ -3,10 +3,12 @@
 
 int sumid = 0;
 
+bool pair3DError::optimizeCameraParams = false;
+
 pair3DError::pair3DError(double sw, double sh, double sz,double dw, double dh, double dz, double weight) : sw(sw), sh(sh), sz(sz), dw(dw), dh(dh), dz(dz), weight(weight) \
 {
     id = sumid++;
-    optimizeCameraParams = false;
+    //optimizeCameraParams = true;
     information = 1.0/1.5;
 }
 
@@ -42,8 +44,8 @@ bool pair3DError::Evaluate(double const* const* parameters, double* residuals, d
     double cy = CameraParameters::get().cy();
 
     if(optimizeCameraParams){
-        invfx = params[0];
-        invfy = params[1];
+        invfx = fabs(params[0]);
+        invfy = fabs(params[1]);
         cx = params[2];
         cy = params[3];
     }


### PR DESCRIPTION
This PR integrates quasimodo with the world_state representation of the object search framework. It enables us to use the mongodb observations intermixed with the meta room ones. Further, it uses this representation to enable @jekekrantz to query for top matches among his built models to speed up matching of models in his database. This will be used to associate observations from @jayyoung 's object search system.

If @jekekrantz could test this before merging, that would be good. Note that when searching for objects in your models, you need to pass the flag `query_msg.query_kind = quasimodo_msgs::retrieval_query::MONGODB_QUERY`.
To add a model to the database, you need to have `mongodb` running, as well as `rosrun quasimodo_object_search insert_object_server.py`. You then need to pass a service according to this definition, in `quasimodo_msgs/insert_model.srv`:

```
uint64 INSERT=1
uint64 REMOVE=2
uint64 action
quasimodo_msgs/model model
string object_id

---
uint64 vocabulary_id
string object_id
```

This is currently announced at `/insert_model_service`. For `INSERT`, you only need to pass the `model` argument. You then get an `object_id` back that you need to keep track of. When you want to remove this model again, pass `REMOVE` together with the `object_id`.

@jayyoung If you have `soma_manager/soma2_local.launch` running together with `quasimodo_object_search/create_object_search_observation.py`, this code will automatically add new entries added to the `world_state` database. For querying these observations, the procedure is the same as above. ATM, you need a `semanticMap` database to train the underlying representation to be able to use this.
